### PR TITLE
Wipe database (truncate all models) before test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "jest": {
     "verbose": true,
     "testEnvironment": "node",
+    "globalSetup": "./test/global-setup.js",
     "globalTeardown": "./test/global-teardown.js",
     "setupTestFrameworkScriptFile": "./test/test-setup.js"
   }

--- a/test/global-setup.js
+++ b/test/global-setup.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const {forEach} = require('lodash')
+const User = require('../models/user')
+const Event = require('../models/event')
+const Score = require('../models/score')
+const ApiKey = require('../models/api-key')
+
+module.exports = () => {
+  // Destroy all Model instances (wipe the database)
+  const models = [User, Event, Score, ApiKey]
+  const destroyed = []
+  forEach(models, (value) => {
+    destroyed.push(value.destroy({truncate: true}))
+  })
+  return Promise.all(destroyed)
+}

--- a/test/global-teardown.js
+++ b/test/global-teardown.js
@@ -1,13 +1,8 @@
 'use strict'
 
 const sequelize = require('../config/sequelize')
-const {forEach} = require('lodash')
 
 module.exports = () => {
-  // Destroy all Model instances (wipe the database) then close database connections
-  const destroyed = []
-  forEach(sequelize.models || [], (value) => {
-    destroyed.push(value.destroy({truncate: true}))
-  })
-  return Promise.all(destroyed).then(() => sequelize.close())
+  // close database connections
+  return sequelize.close()
 }


### PR DESCRIPTION
I moved this functionality to global teardown in 1b2c910ca8f95c21498c4626857c4a25b769734f but it wasn't functioning correctly. Added it back to global setup. It might be beneficial to have a method in the future that can do this before specific tests.