### PR TITLE
KMA-17 - Create JWT handler

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -8,7 +8,9 @@ const api = express()
 const rollbar = require('../config/rollbar')
 const bodyParser = require('body-parser')
 const jsonErrorHandler = require(path.join(__dirname, 'errors/jsonHandler'))
+const jwt = require('express-jwt')
 
+api.use(jwt({ secret: process.env.JWT_SECRET }))
 api.use(bodyParser.json())
 api.use(swaggerizeExpress({
   api: path.join(__dirname, 'scale-of-belief.yml'),

--- a/api/scale-of-belief.yml
+++ b/api/scale-of-belief.yml
@@ -35,6 +35,7 @@ paths:
           format: uri
       security:
         - ApiKeyAuth: []
+        - JwtAuth: []
       responses:
         200:
           description: OK
@@ -58,6 +59,7 @@ paths:
             $ref: '#/definitions/ContentScore'
       security:
         - ApiKeyAuth: []
+        - JwtAuth: []
       responses:
         200:
           description: OK
@@ -81,6 +83,7 @@ paths:
           format: uri
       security:
         - ApiKeyAuth: []
+        - JwtAuth: []
       responses:
         200:
           description: OK
@@ -105,6 +108,7 @@ paths:
           format: uri
       security:
         - ApiKeyAuth: []
+        - JwtAuth: []
       responses:
         200:
           description: OK
@@ -123,6 +127,11 @@ securityDefinitions:
     name: X-Api-Key
     in: header
     x-authorize: 'security/api-key-authorize.js'
+  JwtAuth:
+    type: apiKey
+    name: Authorization
+    in: header
+    x-authorize: 'security/jwt-authorize.js'
 
 responses:
   NotFound:

--- a/api/security/api-key-authorize.test.js
+++ b/api/security/api-key-authorize.test.js
@@ -65,7 +65,7 @@ describe('Api Key Authorizer', () => {
     let unauthorizedError = new Error('Unauthorized')
     unauthorizedError.status = 401
 
-    test('should should return Unauthorized on GET request', done => {
+    test('should return Unauthorized on GET request', done => {
       const request = {
         method: 'GET',
         query: {
@@ -84,7 +84,7 @@ describe('Api Key Authorizer', () => {
       Authorizer(request, response, next)
     })
 
-    test('should should return Unauthorized on POST request', done => {
+    test('should return Unauthorized on POST request', done => {
       const request = {
         method: 'POST',
         body: {
@@ -118,7 +118,7 @@ describe('Api Key Authorizer', () => {
     let unauthorizedError = new Error('You do not have access to this resource')
     unauthorizedError.status = 401
 
-    test('should should return Unauthorized on GET request', done => {
+    test('should return Unauthorized on GET request', done => {
       const request = {
         method: 'GET',
         query: {
@@ -137,7 +137,7 @@ describe('Api Key Authorizer', () => {
       Authorizer(request, response, next)
     })
 
-    test('should should return Unauthorized on POST request', done => {
+    test('should return Unauthorized on POST request', done => {
       const request = {
         method: 'POST',
         body: {

--- a/api/security/jwt-authorize.js
+++ b/api/security/jwt-authorize.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const ApiUser = require('../../models/api-user')
+const {find} = require('lodash')
+
+module.exports = function authorize (request, response, next) {
+  validate(request, function (error, availableScopes) {
+    if (!error) {
+      if (!availableScopes || !availableScopes.length) {
+        next(buildUnauthorized(error))
+      } else {
+        var requestedResource
+
+        if (request.method === 'GET') {
+          requestedResource = request.query['uri']
+        } else {
+          requestedResource = request.body['uri']
+        }
+        if (isAuthorized(availableScopes, requestedResource)) {
+          next()
+        } else {
+          next(buildUnauthorized(error))
+        }
+      }
+    } else {
+      next(error)
+    }
+  })
+}
+
+function isAuthorized (availableScopes, requestedResource) {
+  requestedResource = requestedResource.toLowerCase()
+  var authorized = false
+
+  if (Array.isArray(availableScopes)) {
+    authorized = find(availableScopes, function (scope) {
+      return requestedResource.match(scope)
+    })
+  } else {
+    if (requestedResource.match(availableScopes)) {
+      authorized = true
+    }
+  }
+
+  return authorized
+}
+
+function buildUnauthorized (error) {
+  error = new Error('You do not have access to this resource')
+  error.status = 401
+  return error
+}
+
+function validate (request, callback) {
+  if (!request.user || !request.user.guid) {
+    callback(buildInvalidApiKey(), [])
+  } else {
+    determineScopes(request.user.guid, callback)
+  }
+}
+
+function determineScopes (auth, callback) {
+  ApiUser.findOne(
+    {
+      where: {
+        guid: auth
+      }
+    }).then((dbApiUser) => {
+      if (dbApiUser) {
+        var apiPatterns = dbApiUser.api_pattern
+        callback(null, apiPatterns)
+      } else {
+        callback(buildInvalidApiKey(), [])
+      }
+    }).catch(function (error) {
+      console.log(error)
+      callback(buildInvalidApiKey(), [])
+    })
+}
+
+function buildInvalidApiKey () {
+  var error = new Error('Unauthorized')
+  error.status = 401
+  return error
+}

--- a/api/security/jwt-authorize.test.js
+++ b/api/security/jwt-authorize.test.js
@@ -1,0 +1,235 @@
+'use strict'
+
+const ApiUser = require('../../models/api-user')
+const JwtAuthorizer = require('./jwt-authorize')
+
+/*
+ * Note: express-jwt handles the parsing of the JWT. If the parsing succeeds,
+ * the request will have a user object with the values from the JWT inside.
+ */
+describe('JWT Authorizer', () => {
+  let response = {}
+  let guid = 'some-guid'
+
+  test('is defined', () => {
+    expect(JwtAuthorizer).toBeDefined()
+  })
+
+  describe('has valid JWT', () => {
+    let apiUser = {
+      guid: guid,
+      api_pattern: [
+        '.*'
+      ]
+    }
+
+    test('should succeed on GET request', done => {
+      const request = {
+        method: 'GET',
+        query: {
+          uri: 'http://some.uri.com'
+        },
+        user: {
+          guid: guid
+        }
+      }
+
+      const next = (error) => {
+        expect(error).toBeUndefined()
+        done()
+      }
+      jest.spyOn(ApiUser, 'findOne').mockImplementation(() => Promise.resolve(apiUser))
+
+      JwtAuthorizer(request, response, next)
+    })
+
+    test('should succeed on POST request', done => {
+      const request = {
+        method: 'POST',
+        body: {
+          uri: 'http://some.uri.com'
+        },
+        user: {
+          guid: guid
+        }
+      }
+
+      const next = (error) => {
+        expect(error).toBeUndefined()
+        done()
+      }
+      jest.spyOn(ApiUser, 'findOne').mockImplementation(() => Promise.resolve(apiUser))
+
+      JwtAuthorizer(request, response, next)
+    })
+  })
+
+  // Note: express-jwt should catch the issue with its own handling before our application logic ever gets called
+  describe('has invalid JWT', () => {
+    let unauthorizedError = new Error('Unauthorized')
+    unauthorizedError.status = 401
+
+    test('should should return Unauthorized on GET request', done => {
+      const request = {
+        method: 'GET',
+        query: {
+          uri: 'http://some.uri.com'
+        }
+      }
+
+      const next = (error) => {
+        expect(error).toBeDefined()
+        expect(error).toEqual(unauthorizedError)
+        done()
+      }
+      jest.spyOn(ApiUser, 'findOne').mockImplementation(() => Promise.resolve(null))
+
+      JwtAuthorizer(request, response, next)
+    })
+
+    test('should should return Unauthorized on POST request', done => {
+      const request = {
+        method: 'POST',
+        body: {
+          uri: 'http://some.uri.com'
+        }
+      }
+
+      const next = (error) => {
+        expect(error).toBeDefined()
+        expect(error).toEqual(unauthorizedError)
+        done()
+      }
+      jest.spyOn(ApiUser, 'findOne').mockImplementation(() => Promise.resolve(null))
+
+      JwtAuthorizer(request, response, next)
+    })
+  })
+
+  describe('has JWT without access to resource', () => {
+    let apiUser = {
+      guid: guid,
+      api_pattern: [
+        '.*nowhere.*'
+      ]
+    }
+
+    let unauthorizedError = new Error('You do not have access to this resource')
+    unauthorizedError.status = 401
+
+    test('should return Unauthorized on GET request', done => {
+      const request = {
+        method: 'GET',
+        query: {
+          uri: 'http://some.uri.com'
+        },
+        user: {
+          guid: guid
+        }
+      }
+
+      const next = (error) => {
+        expect(error).toBeDefined()
+        expect(error).toEqual(unauthorizedError)
+        done()
+      }
+      jest.spyOn(ApiUser, 'findOne').mockImplementation(() => Promise.resolve(apiUser))
+
+      JwtAuthorizer(request, response, next)
+    })
+
+    test('should return Unauthorized on POST request', done => {
+      const request = {
+        method: 'POST',
+        body: {
+          uri: 'http://some.uri.com'
+        },
+        user: {
+          guid: guid
+        }
+      }
+
+      const next = (error) => {
+        expect(error).toBeDefined()
+        expect(error).toEqual(unauthorizedError)
+        done()
+      }
+      jest.spyOn(ApiUser, 'findOne').mockImplementation(() => Promise.resolve(apiUser))
+
+      JwtAuthorizer(request, response, next)
+    })
+  })
+
+  describe('fails database lookup', () => {
+    let unauthorizedError = new Error('Unauthorized')
+    unauthorizedError.status = 401
+
+    test('should return Unauthorized', done => {
+      const request = {
+        method: 'GET',
+        query: {
+          uri: 'http://some.uri.com'
+        },
+        user: {
+          guid: 'fail'
+        }
+      }
+
+      const next = (error) => {
+        expect(error).toBeDefined()
+        expect(error).toEqual(unauthorizedError)
+        done()
+      }
+      jest.spyOn(ApiUser, 'findOne').mockImplementation(() => Promise.reject(new Error('guid is not a valid uuid')))
+
+      JwtAuthorizer(request, response, next)
+    })
+  })
+
+  describe('has JWT with non-existing user in local database', () => {
+    let unauthorizedError = new Error('Unauthorized')
+    unauthorizedError.status = 401
+
+    test('should should return Unauthorized on GET request', done => {
+      const request = {
+        method: 'GET',
+        query: {
+          uri: 'http://some.uri.com'
+        },
+        user: {
+          guid: 'other-guid'
+        }
+      }
+
+      const next = (error) => {
+        expect(error).toBeDefined()
+        expect(error).toEqual(unauthorizedError)
+        done()
+      }
+      jest.spyOn(ApiUser, 'findOne').mockImplementation(() => Promise.resolve(null))
+
+      JwtAuthorizer(request, response, next)
+    })
+
+    test('should should return Unauthorized on POST request', done => {
+      const request = {
+        method: 'POST',
+        body: {
+          uri: 'http://some.uri.com'
+        },
+        user: {
+          guid: 'other-guid'
+        }
+      }
+
+      const next = (error) => {
+        expect(error).toBeDefined()
+        expect(error).toEqual(unauthorizedError)
+        done()
+      }
+      jest.spyOn(ApiUser, 'findOne').mockImplementation(() => Promise.resolve(null))
+
+      JwtAuthorizer(request, response, next)
+    })
+  })
+})

--- a/db/migrate/20180326102300-create-api-user.js
+++ b/db/migrate/20180326102300-create-api-user.js
@@ -1,0 +1,30 @@
+'use strict'
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('api_users', {
+      guid: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.UUID
+      },
+      api_pattern: {
+        type: Sequelize.ARRAY(Sequelize.STRING),
+        defaultValue: []
+      },
+      contact_email: {
+        type: Sequelize.STRING
+      },
+      created_at: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updated_at: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    })
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('api_users')
+  }
+}

--- a/models/api-user.js
+++ b/models/api-user.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const {DataTypes} = require('sequelize')
+const sequelize = require('../config/sequelize')
+const ApiUser = sequelize.define('ApiUser', {
+  guid: {
+    type: DataTypes.UUID,
+    primaryKey: true
+  },
+  api_pattern: DataTypes.ARRAY(DataTypes.STRING),
+  contact_email: DataTypes.STRING
+}, {
+  tableName: 'api_users',
+  underscored: true
+})
+
+module.exports = ApiUser

--- a/models/score.test.js
+++ b/models/score.test.js
@@ -42,10 +42,6 @@ describe('Score', () => {
       return factory.create('existing_score').then(existingScore => { score = existingScore })
     })
 
-    afterEach(() => {
-      return Score.destroy({truncate: true})
-    })
-
     it('should return an existing score', done => {
       Score.retrieve(score.uri).then((result) => {
         expect(result).toBeDefined()

--- a/package-lock.json
+++ b/package-lock.json
@@ -809,8 +809,7 @@
     "base64url": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs=",
-      "dev": true
+      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -957,8 +956,7 @@
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
-      "dev": true
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-writer": {
       "version": "1.0.1",
@@ -2033,7 +2031,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
       "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
-      "dev": true,
       "requires": {
         "base64url": "2.0.0",
         "safe-buffer": "5.1.1"
@@ -2730,6 +2727,51 @@
         "utils-merge": "1.0.1",
         "vary": "1.1.2"
       }
+    },
+    "express-jwt": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/express-jwt/-/express-jwt-5.3.1.tgz",
+      "integrity": "sha512-1C9RNq0wMp/JvsH/qZMlg3SIPvKu14YkZ4YYv7gJQ1Vq+Dv8LH9tLKenS5vMNth45gTlEUGx+ycp9IHIlaHP/g==",
+      "requires": {
+        "async": "1.5.2",
+        "express-unless": "0.3.1",
+        "jsonwebtoken": "8.2.0",
+        "lodash.set": "4.3.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "jsonwebtoken": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.0.tgz",
+          "integrity": "sha512-1Wxh8ADP3cNyPl8tZ95WtraHXCAyXupgc0AhMHjU9er98BV+UcKsO7OJUjfhIu0Uba9A40n1oSx8dbJYrm+EoQ==",
+          "requires": {
+            "jws": "3.1.4",
+            "lodash.includes": "4.3.0",
+            "lodash.isboolean": "3.0.3",
+            "lodash.isinteger": "4.0.4",
+            "lodash.isnumber": "3.0.3",
+            "lodash.isplainobject": "4.0.6",
+            "lodash.isstring": "4.0.1",
+            "lodash.once": "4.1.1",
+            "ms": "2.1.1",
+            "xtend": "4.0.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "express-unless": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/express-unless/-/express-unless-0.3.1.tgz",
+      "integrity": "sha1-JVfBRudb65A+LSR/m1ugFFJpbiA="
     },
     "extend": {
       "version": "3.0.0",
@@ -5947,7 +5989,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
       "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
-      "dev": true,
       "requires": {
         "base64url": "2.0.0",
         "buffer-equal-constant-time": "1.0.1",
@@ -5959,7 +6000,6 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
       "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
-      "dev": true,
       "requires": {
         "base64url": "2.0.0",
         "jwa": "1.1.5",
@@ -6115,11 +6155,40 @@
       "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
       "dev": true
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
-      "dev": true
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.pad": {
       "version": "4.5.1",
@@ -6138,6 +6207,11 @@
       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
       "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
       "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "body-parser": "^1.18.2",
     "dotenv": "^5.0.0",
     "express": "^4.16.2",
+    "express-jwt": "^5.3.1",
     "glob": "^7.1.2",
     "pg": "^7.4.1",
     "pg-hstore": "^2.3.2",


### PR DESCRIPTION
This PR creates a JWT security handler to handle JWT that will come in (after KMA-16 transforms the CAS service tickets into JWTs). `express-jwt` handles the actual JWT validation before our security handler gets called, but there is some backup validation logic in there as well.