### PR TITLE
KMA-16 - service ticket endpoint

### DIFF
--- a/api/controllers/login.js
+++ b/api/controllers/login.js
@@ -3,6 +3,7 @@
 const https = require('https')
 const jwt = require('jsonwebtoken')
 const logger = require('../../config/logger')
+const util = require('../util/util')
 
 const get = (request, response) => {
   request.body = {
@@ -16,20 +17,20 @@ const post = (request, response) => {
   var serviceTicket = request.body['ticket']
 
   if (!serviceTicket) {
-    buildUnauthorized(response)
+    util.buildUnauthorizedResponse(response)
     return
   }
 
   validateTicket(serviceTicket, (data) => {
     if (!data) {
-      buildInternalErrorResponse(response)
+      util.buildInternalErrorResponse(response)
       return
     }
 
     var json = JSON.parse(data)
     if (json.serviceResponse.authenticationFailure) {
       logger.debug('Login failure: ' + json.serviceResponse.authenticationFailure.description)
-      buildUnauthorized(response)
+      util.buildUnauthorizedResponse(response)
       return
     }
     var guid = json.serviceResponse.authenticationSuccess.attributes.theKeyGuid[0].toLowerCase()
@@ -68,24 +69,10 @@ const buildJwt = (guid, response) => {
   jwt.sign({ guid: guid }, process.env.JWT_SECRET, { expiresIn: '1h' }, (error, token) => {
     if (error) {
       logger.error(error)
-      buildInternalErrorResponse(response)
+      util.buildInternalErrorResponse(response)
     } else {
       response.json(token)
     }
-  })
-}
-
-const buildUnauthorized = (response) => {
-  response.status(401)
-  response.json({
-    message: 'Unauthorized'
-  })
-}
-
-const buildInternalErrorResponse = (response) => {
-  response.status(500)
-  response.json({
-    message: 'Internal Server Error'
   })
 }
 

--- a/api/controllers/login.js
+++ b/api/controllers/login.js
@@ -41,8 +41,8 @@ const post = (request, response) => {
 
 const validateTicket = (serviceTicket, callback) => {
   var path = '/cas/p3/serviceValidate'
-  var service = 'service=' + process.env.THE_KEY_SERVICE_URL
-  var ticket = 'ticket=' + serviceTicket
+  var service = 'service=' + encodeURIComponent(process.env.THE_KEY_SERVICE_URL)
+  var ticket = 'ticket=' + encodeURIComponent(serviceTicket)
   const format = 'format=JSON'
   const options = {
     hostname: 'thekey.me',

--- a/api/controllers/login.js
+++ b/api/controllers/login.js
@@ -34,7 +34,7 @@ const post = (request, response) => {
       util.buildUnauthorizedResponse(response)
       return
     }
-    var guid = json.serviceResponse.authenticationSuccess.attributes.theKeyGuid[0].toLowerCase()
+    var guid = json.serviceResponse.authenticationSuccess.attributes.ssoGuid[0].toLowerCase()
     buildJwt(guid, response)
   })
 }

--- a/api/controllers/login.js
+++ b/api/controllers/login.js
@@ -5,6 +5,7 @@ const jwt = require('jsonwebtoken')
 const logger = require('../../config/logger')
 const util = require('../util/util')
 
+/* istanbul ignore next */
 const get = (request, response) => {
   request.body = {
     ticket: request.query['ticket']

--- a/api/controllers/login.js
+++ b/api/controllers/login.js
@@ -1,0 +1,92 @@
+'use strict'
+
+const https = require('https')
+const jwt = require('jsonwebtoken')
+const logger = require('../../config/logger')
+
+const get = (request, response) => {
+  request.body = {
+    ticket: request.query['ticket']
+  }
+
+  post(request, response)
+}
+
+const post = (request, response) => {
+  var serviceTicket = request.body['ticket']
+
+  if (!serviceTicket) {
+    buildUnauthorized(response)
+    return
+  }
+
+  validateTicket(serviceTicket, (data) => {
+    if (!data) {
+      buildInternalErrorResponse(response)
+      return
+    }
+
+    var json = JSON.parse(data)
+    if (json.serviceResponse.authenticationFailure) {
+      logger.debug('Login failure: ' + json.serviceResponse.authenticationFailure.description)
+      buildUnauthorized(response)
+      return
+    }
+    var guid = json.serviceResponse.authenticationSuccess.attributes.theKeyGuid[0].toLowerCase()
+    buildJwt(guid, response)
+  })
+}
+
+const validateTicket = (serviceTicket, callback) => {
+  var path = '/cas/p3/serviceValidate'
+  var service = 'service=' + process.env.THE_KEY_SERVICE_URL
+  var ticket = 'ticket=' + serviceTicket
+  const format = 'format=JSON'
+  const options = {
+    hostname: 'thekey.me',
+    path: path + '?' + service + '&' + ticket + '&' + format,
+    method: 'GET'
+  }
+
+  var request = https.request(options, (response) => {
+    response.setEncoding('utf8')
+
+    response.on('data', (data) => {
+      callback(data)
+    })
+  })
+
+  request.on('error', (error) => {
+    logger.error(error)
+    callback(null)
+  })
+
+  request.end()
+}
+
+const buildJwt = (guid, response) => {
+  jwt.sign({ guid: guid }, process.env.JWT_SECRET, { expiresIn: '1h' }, (error, token) => {
+    if (error) {
+      logger.error(error)
+      buildInternalErrorResponse(response)
+    } else {
+      response.json(token)
+    }
+  })
+}
+
+const buildUnauthorized = (response) => {
+  response.status(401)
+  response.json({
+    message: 'Unauthorized'
+  })
+}
+
+const buildInternalErrorResponse = (response) => {
+  response.status(500)
+  response.json({
+    message: 'Internal Server Error'
+  })
+}
+
+module.exports = { get: get, post: post }

--- a/api/index.js
+++ b/api/index.js
@@ -11,7 +11,7 @@ const jsonErrorHandler = require(path.join(__dirname, 'errors/jsonHandler'))
 const jwt = require('express-jwt')
 
 api.use(jwt({ secret: process.env.JWT_SECRET }).unless((request) => {
-  if (request.headers['x-api-key']) {
+  if (request.headers['x-api-key'] || request.path.endsWith('/login')) {
     return true
   }
 }))

--- a/api/scale-of-belief.yml
+++ b/api/scale-of-belief.yml
@@ -120,6 +120,25 @@ paths:
               format: uri
         401:
           $ref: '#/responses/Unauthorized'
+  /login:
+    post:
+      summary: Login to the API
+      tags:
+        - login
+      parameters:
+        - name: body
+          in: body
+          description: Login credentials
+          schema:
+            $ref: '#/definitions/Credentials'
+      security:
+      responses:
+        200:
+          description: OK
+          schema:
+            type: string
+        401:
+          $ref: '#/responses/Unauthorized'
 
 securityDefinitions:
   ApiKeyAuth:
@@ -185,6 +204,13 @@ definitions:
       - follower
       - guide
       - confidence
+  Credentials:
+    type: object
+    properties:
+      ticket:
+        type: string
+    required:
+      - ticket
   Error:
     type: object
     properties:

--- a/api/scale-of-belief.yml
+++ b/api/scale-of-belief.yml
@@ -121,6 +121,21 @@ paths:
         401:
           $ref: '#/responses/Unauthorized'
   /login:
+    get:
+      summary: Testing
+      tags:
+        - login
+      parameters:
+        - name: ticket
+          description: Service ticket
+          in: query
+          type: string
+      security:
+      responses:
+        200:
+          description: OK
+          schema:
+            type: string
     post:
       summary: Login to the API
       tags:

--- a/api/security/jwt-authorize.js
+++ b/api/security/jwt-authorize.js
@@ -3,12 +3,13 @@
 const ApiUser = require('../../models/api-user')
 const {find} = require('lodash')
 const logger = require('../../config/logger')
+const util = require('../util/util')
 
 module.exports = function authorize (request, response, next) {
   validate(request, function (error, availableScopes) {
     if (!error) {
       if (!availableScopes || !availableScopes.length) {
-        next(buildUnauthorized(error))
+        next(util.buildUnauthorizedError(error))
       } else {
         var requestedResource
 
@@ -20,7 +21,7 @@ module.exports = function authorize (request, response, next) {
         if (isAuthorized(availableScopes, requestedResource)) {
           next()
         } else {
-          next(buildUnauthorized(error))
+          next(util.buildUnauthorizedError(error))
         }
       }
     } else {
@@ -46,15 +47,9 @@ function isAuthorized (availableScopes, requestedResource) {
   return authorized
 }
 
-function buildUnauthorized (error) {
-  error = new Error('You do not have access to this resource')
-  error.status = 401
-  return error
-}
-
 function validate (request, callback) {
   if (!request.user || !request.user.guid) {
-    callback(buildInvalidApiKey(), [])
+    callback(util.buildInvalidApiKey(), [])
   } else {
     determineScopes(request.user.guid, callback)
   }
@@ -71,16 +66,10 @@ function determineScopes (auth, callback) {
         var apiPatterns = dbApiUser.api_pattern
         callback(null, apiPatterns)
       } else {
-        callback(buildInvalidApiKey(), [])
+        callback(util.buildInvalidApiKey(), [])
       }
     }).catch(function (error) {
       logger.error(error)
-      callback(buildInvalidApiKey(), [])
+      callback(util.buildInvalidApiKey(), [])
     })
-}
-
-function buildInvalidApiKey () {
-  var error = new Error('Unauthorized')
-  error.status = 401
-  return error
 }

--- a/api/util/util.js
+++ b/api/util/util.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const buildUnauthorizedResponse = (response) => {
+  response.status(401)
+  response.json({
+    message: 'Unauthorized'
+  })
+}
+
+const buildUnauthorizedError = (error) => {
+  error = new Error('You do not have access to this resource')
+  error.status = 401
+  return error
+}
+
+const buildInvalidApiKey = () => {
+  var error = new Error('Unauthorized')
+  error.status = 401
+  return error
+}
+
+const buildInternalErrorResponse = (response) => {
+  response.status(500)
+  response.json({
+    message: 'Internal Server Error'
+  })
+}
+
+module.exports = {
+  buildUnauthorizedResponse: buildUnauthorizedResponse,
+  buildUnauthorizedError: buildUnauthorizedError,
+  buildInvalidApiKey: buildInvalidApiKey,
+  buildInternalErrorResponse: buildInternalErrorResponse
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1061,6 +1061,11 @@
       "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true
     },
+    "cas": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/cas/-/cas-0.0.3.tgz",
+      "integrity": "sha1-V4aVm8o8Qs0FWasc3KBOhqTpHD4="
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -4635,6 +4640,11 @@
         "sshpk": "1.14.1"
       }
     },
+    "https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
+      "integrity": "sha1-PDfHrhqO65ZpBKKtHpdaGUt+06Q="
+    },
     "https-proxy-agent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
@@ -5969,16 +5979,27 @@
       "dev": true
     },
     "jsonwebtoken": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
-      "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=",
-      "dev": true,
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.0.tgz",
+      "integrity": "sha512-1Wxh8ADP3cNyPl8tZ95WtraHXCAyXupgc0AhMHjU9er98BV+UcKsO7OJUjfhIu0Uba9A40n1oSx8dbJYrm+EoQ==",
       "requires": {
-        "joi": "6.10.1",
         "jws": "3.1.4",
+        "lodash.includes": "4.3.0",
+        "lodash.isboolean": "3.0.3",
+        "lodash.isinteger": "4.0.4",
+        "lodash.isnumber": "3.0.3",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
         "lodash.once": "4.1.1",
-        "ms": "2.0.0",
+        "ms": "2.1.1",
         "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "jsprim": {
@@ -8437,6 +8458,21 @@
         "jsonwebtoken": "7.4.3",
         "lodash": "4.17.5",
         "velocityjs": "0.9.6"
+      },
+      "dependencies": {
+        "jsonwebtoken": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
+          "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=",
+          "dev": true,
+          "requires": {
+            "joi": "6.10.1",
+            "jws": "3.1.4",
+            "lodash.once": "4.1.1",
+            "ms": "2.0.0",
+            "xtend": "4.0.1"
+          }
+        }
       }
     },
     "serverless-plugin-bind-deployment-id": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1061,11 +1061,6 @@
       "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true
     },
-    "cas": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/cas/-/cas-0.0.3.tgz",
-      "integrity": "sha1-V4aVm8o8Qs0FWasc3KBOhqTpHD4="
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,10 +35,13 @@
   },
   "dependencies": {
     "body-parser": "^1.18.2",
+    "cas": "0.0.3",
     "dotenv": "^5.0.0",
     "express": "^4.16.2",
     "express-jwt": "^5.3.1",
     "glob": "^7.1.2",
+    "https": "^1.0.0",
+    "jsonwebtoken": "^8.2.0",
     "pg": "^7.4.1",
     "pg-hstore": "^2.3.2",
     "rollbar": "^2.3.9",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "body-parser": "^1.18.2",
-    "cas": "0.0.3",
     "dotenv": "^5.0.0",
     "express": "^4.16.2",
     "express-jwt": "^5.3.1",

--- a/serverless/environment.js
+++ b/serverless/environment.js
@@ -10,6 +10,7 @@ module.exports = () => {
     DB_ENV_POSTGRESQL_PASS: process.env['DB_ENV_POSTGRESQL_PASS'] || '',
     DB_PORT_5432_TCP_ADDR: process.env['DB_PORT_5432_TCP_ADDR'] || 'localhost',
     DB_PORT_5432_TCP_PORT: process.env['DB_PORT_5432_TCP_PORT'] || 5432,
-    ROLLBAR_ACCESS_TOKEN: process.env['ROLLBAR_ACCESS_TOKEN'] || ''
+    ROLLBAR_ACCESS_TOKEN: process.env['ROLLBAR_ACCESS_TOKEN'] || '',
+    THE_KEY_SERVICE_URL: process.env['THE_KEY_SERVICE_URL'] || 'http://localhost:3000/api/login'
   }
 }

--- a/serverless/environment.js
+++ b/serverless/environment.js
@@ -11,6 +11,7 @@ module.exports = () => {
     DB_PORT_5432_TCP_ADDR: process.env['DB_PORT_5432_TCP_ADDR'] || 'localhost',
     DB_PORT_5432_TCP_PORT: process.env['DB_PORT_5432_TCP_PORT'] || 5432,
     ROLLBAR_ACCESS_TOKEN: process.env['ROLLBAR_ACCESS_TOKEN'] || '',
+    JWT_SECRET: process.env['JWT_SECRET'] || 'secret',
     THE_KEY_SERVICE_URL: process.env['THE_KEY_SERVICE_URL'] || 'http://localhost:3000/api/login'
   }
 }

--- a/test/controllers/login.test.js
+++ b/test/controllers/login.test.js
@@ -18,7 +18,7 @@ describe('LoginController', () => {
         '"serviceResponse": {' +
           '"authenticationSuccess": {' +
             '"attributes": {' +
-              '"theKeyGuid": ["' + guid + '"] ' +
+              '"ssoGuid": ["' + guid + '"] ' +
             '}' +
           '}' +
         '}' +
@@ -194,7 +194,7 @@ describe('LoginController', () => {
         '"serviceResponse": {' +
           '"authenticationSuccess": {' +
             '"attributes": {' +
-              '"theKeyGuid": ["' + guid + '"] ' +
+              '"ssoGuid": ["' + guid + '"] ' +
             '}' +
           '}' +
         '}' +

--- a/test/controllers/login.test.js
+++ b/test/controllers/login.test.js
@@ -1,0 +1,249 @@
+'use strict'
+
+const LoginController = require('../../api/controllers/login.js')
+const https = require('https')
+const jwt = require('jsonwebtoken')
+
+describe('LoginController', () => {
+  it('should be defined', () => {
+    expect(LoginController).toBeDefined()
+  })
+
+  describe('has a valid service ticket', () => {
+    it('should return a JWT', done => {
+      const serviceTicket = 'valid-ticket'
+      const guid = 'valid-guid'
+      const validToken = 'valid-jwt'
+      var personData = '{' +
+        '"serviceResponse": {' +
+          '"authenticationSuccess": {' +
+            '"attributes": {' +
+              '"theKeyGuid": ["' + guid + '"] ' +
+            '}' +
+          '}' +
+        '}' +
+      '}'
+      const httpsResponse = {
+        data: personData,
+        setEncoding: (encoding) => {
+          // do nothing
+        },
+        on: (key, callback) => {
+          callback(personData)
+        }
+      }
+
+      var response = {
+        json: (jsonToSet) => {
+          expect(jsonToSet).toBeDefined()
+          expect(jsonToSet).toEqual(validToken)
+          done()
+        }
+      }
+
+      var req = {
+        on: (key, callback) => {
+          // do nothing
+        },
+        end: () => {
+          done()
+        }
+      }
+
+      jest.spyOn(https, 'request').mockImplementation((options, callback) => {
+        callback(httpsResponse)
+        return req
+      })
+
+      jest.spyOn(jwt, 'sign').mockImplementation((guid, secret, expires, callback) => { callback(null, validToken) })
+
+      const request = {
+        body: {
+          ticket: serviceTicket
+        }
+      }
+
+      LoginController.post(request, response)
+    })
+  })
+
+  describe('has an invalid service ticket', () => {
+    it('should return Unauthorized', done => {
+      const serviceTicket = 'invalid-ticket'
+      var failureData = '{' +
+        '"serviceResponse": {' +
+          '"authenticationFailure": {' +
+            '"description": "Failed",' +
+            '"code": "FAIL"' +
+          '}' +
+        '}' +
+      '}'
+      const httpsResponse = {
+        data: failureData,
+        setEncoding: (encoding) => {
+          // do nothing
+        },
+        on: (key, callback) => {
+          callback(failureData)
+        }
+      }
+
+      var response = {
+        json: (jsonToSet) => {
+          expect(jsonToSet).toBeDefined()
+          expect(jsonToSet).toEqual({ message: 'Unauthorized' })
+          done()
+        },
+        status: (statusToSet) => {
+          expect(statusToSet).toBeDefined()
+          expect(statusToSet).toEqual(401)
+        }
+      }
+
+      var req = {
+        on: (key, callback) => {
+          // do nothing
+        },
+        end: () => {
+          done()
+        }
+      }
+
+      jest.spyOn(https, 'request').mockImplementation((options, callback) => {
+        callback(httpsResponse)
+        return req
+      })
+
+      const request = {
+        body: {
+          ticket: serviceTicket
+        }
+      }
+
+      LoginController.post(request, response)
+    })
+  })
+
+  describe('has no service ticket', () => {
+    it('should return Unauthorized', done => {
+      var response = {
+        json: (jsonToSet) => {
+          expect(jsonToSet).toBeDefined()
+          expect(jsonToSet).toEqual({ message: 'Unauthorized' })
+          done()
+        },
+        status: (statusToSet) => {
+          expect(statusToSet).toBeDefined()
+          expect(statusToSet).toEqual(401)
+        }
+      }
+
+      const request = {
+        body: {}
+      }
+
+      LoginController.post(request, response)
+    })
+  })
+
+  describe('receives a failure from CAS', () => {
+    it('should return Internal Error', done => {
+      const serviceTicket = 'ticket'
+
+      var response = {
+        json: (jsonToSet) => {
+          expect(jsonToSet).toBeDefined()
+          expect(jsonToSet).toEqual({ message: 'Internal Server Error' })
+          done()
+        },
+        status: (statusToSet) => {
+          expect(statusToSet).toBeDefined()
+          expect(statusToSet).toEqual(500)
+        }
+      }
+
+      var req = {
+        on: (key, callback) => {
+          expect(key).toEqual('error')
+          callback(new Error())
+        },
+        end: () => {
+          done()
+        }
+      }
+
+      jest.spyOn(https, 'request').mockImplementation((options, callback) => {
+        return req
+      })
+
+      const request = {
+        body: {
+          ticket: serviceTicket
+        }
+      }
+
+      LoginController.post(request, response)
+    })
+  })
+
+  describe('receives a failure when signing the JWT', () => {
+    it('should return an Internal Server Error', done => {
+      const serviceTicket = 'ticket'
+      const guid = 'valid-guid'
+      var personData = '{' +
+        '"serviceResponse": {' +
+          '"authenticationSuccess": {' +
+            '"attributes": {' +
+              '"theKeyGuid": ["' + guid + '"] ' +
+            '}' +
+          '}' +
+        '}' +
+      '}'
+      const httpsResponse = {
+        data: personData,
+        setEncoding: (encoding) => {
+          // do nothing
+        },
+        on: (key, callback) => {
+          callback(personData)
+        }
+      }
+
+      var response = {
+        json: (jsonToSet) => {
+          expect(jsonToSet).toBeDefined()
+          expect(jsonToSet).toEqual({ message: 'Internal Server Error' })
+          done()
+        },
+        status: (statusToSet) => {
+          expect(statusToSet).toBeDefined()
+          expect(statusToSet).toEqual(500)
+        }
+      }
+
+      var req = {
+        on: (key, callback) => {
+          // do nothing
+        },
+        end: () => {
+          done()
+        }
+      }
+
+      jest.spyOn(https, 'request').mockImplementation((options, callback) => {
+        callback(httpsResponse)
+        return req
+      })
+
+      jest.spyOn(jwt, 'sign').mockImplementation((guid, secret, expires, callback) => { callback(new Error('Test'), null) })
+
+      const request = {
+        body: {
+          ticket: serviceTicket
+        }
+      }
+
+      LoginController.post(request, response)
+    })
+  })
+})


### PR DESCRIPTION
This PR creates a `/login` endpoint to turn service tickets from The Key into JWTs for the client to use for authentication against the rest of the API.  This will require an environment variable `THE_KEY_SERVICE_URL` to be set up in each environment.