### PR TITLE
Return empty array instead of 404

### DIFF
--- a/api/controllers/scores.js
+++ b/api/controllers/scores.js
@@ -22,10 +22,7 @@ module.exports = {
         })
         response.json(transformedScores)
       } else {
-        response.status(404)
-        response.json({
-          message: 'Not Found'
-        })
+        response.json([])
       }
     })
   }

--- a/api/scale-of-belief.yml
+++ b/api/scale-of-belief.yml
@@ -110,8 +110,6 @@ paths:
               $ref: '#/definitions/ApiUser'
         401:
           $ref: '#/responses/Unauthorized'
-        404:
-          $ref: '#/responses/NotFound'
   /api-user:
     get:
       summary: Get single API User score by guid

--- a/api/scale-of-belief.yml
+++ b/api/scale-of-belief.yml
@@ -93,8 +93,6 @@ paths:
                 $ref: '#/definitions/ContentScore'
           401:
             $ref: '#/responses/Unauthorized'
-          404:
-            $ref: '#/responses/NotFound'
   /api-users:
     get:
       summary: Get API Users

--- a/test/controllers/scores.test.js
+++ b/test/controllers/scores.test.js
@@ -72,7 +72,7 @@ describe('ScoresController', () => {
   })
 
   describe('has no matches', () => {
-    test('should return not found to the client', done => {
+    test('should return an empty array to the client', done => {
       var request = {
         query: {
           uri: 'http://nowhere.com'
@@ -80,13 +80,9 @@ describe('ScoresController', () => {
       }
 
       var response = {
-        status: (statusToSet) => {
-          expect(statusToSet).toBeDefined()
-          expect(statusToSet).toEqual(404)
-        },
         json: (jsonToSet) => {
           expect(jsonToSet).toBeDefined()
-          expect(jsonToSet).toEqual({ message: 'Not Found' })
+          expect(jsonToSet).toEqual([])
           done()
         }
       }


### PR DESCRIPTION
For consistency, return an empty array from `/scores` instead of a 404 when there are no results.