### PR TITLE
Log rollbar locally

### DIFF
--- a/config/rollbar.js
+++ b/config/rollbar.js
@@ -1,7 +1,9 @@
 'use strict'
 
 const Rollbar = require('rollbar')
+const logger = require('./logger')
 const {includes} = require('lodash')
+const proxyMap = {critical: 'crit', error: 'error', warning: 'warning', info: 'info', debug: 'debug'}
 
 const rollbar = new Rollbar({
   // https://rollbar.com/docs/notifier/rollbar.js/#configuration-reference
@@ -13,4 +15,16 @@ const rollbar = new Rollbar({
   }
 })
 
-module.exports = rollbar
+// Proxy specific methods to logger before sending to rollbar
+module.exports = new Proxy(rollbar, {
+  get: function (obj, prop) {
+    if (prop in proxyMap) {
+      const origFunc = obj[prop]
+      return function (...args) {
+        logger[proxyMap[prop]].apply(this, args)
+        return origFunc.apply(this, args)
+      }
+    }
+    return obj[prop]
+  }
+})

--- a/config/rollbar.js
+++ b/config/rollbar.js
@@ -36,7 +36,7 @@ module.exports = new Proxy(rollbar, {
     if (prop in proxyMap) {
       const origFunc = obj[prop]
       return function (...args) {
-        logger[proxyMap[prop]].apply(this, [JSON.stringify(args, errorSerializer, 2)])
+        logger[proxyMap[prop]].apply(this, [JSON.stringify(args, errorSerializer, process.env['IS_LOCAL'] ? 2 : 0)])
         return origFunc.apply(this, args)
       }
     }


### PR DESCRIPTION
This wraps rollbar in a proxy and forwards specific methods to `logger` before sending the request to rollbar. This will allow us to log to rollbar, but still see the errors locally or in CloudWatch.