### PR TITLE
Placement API endpoint

### DIFF
--- a/api/controllers/placement.js
+++ b/api/controllers/placement.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const User = require('../../models/user')
+const Placement = require('../../models/placement')
+const {Op} = require('sequelize')
+const {identity, isEmpty, isNull, mapValues, pickBy} = require('lodash')
+
+const get = (request, response) => {
+  let params = mapValues(pickBy(request.query, identity), (value) => {
+    return {[Op.contains]: [value]}
+  })
+
+  if (isEmpty(params)) {
+    response.status(400)
+    response.json({
+      message: 'Requires at least on query parameter.'
+    })
+    return
+  }
+
+  User.findOne({where: params}).then(user => {
+    if (isNull(user)) {
+      response.status(404)
+      response.json({
+        message: 'Not Found'
+      })
+    } else {
+      new Placement(user).calculate().then(placement => {
+        response.json({placement: placement.placement})
+      }, error => {
+        response.status(400)
+        response.json({
+          message: error.message
+        })
+      })
+    }
+  }, error => {
+    response.status(400)
+    response.json({
+      message: error.message
+    })
+  })
+}
+
+module.exports = {
+  get: get
+}

--- a/api/scale-of-belief.yml
+++ b/api/scale-of-belief.yml
@@ -292,6 +292,58 @@ paths:
             type: string
         401:
           $ref: '#/responses/Unauthorized'
+  /placement:
+    get:
+      summary: Get a users placement on the scale of belief
+      tags:
+        - placement
+      parameters:
+        - name: mcid
+          description: Adobe Experience Cloud ID
+          in: query
+          type: string
+        - name: sso_guid
+          description: SSO Guid
+          in: query
+          type: string
+        - name: gr_master_person_id
+          description: Global Registry master_person uuid
+          in: query
+          type: string
+        - name: device_idfa
+          description: Mobile device idfa
+          in: query
+          type: string
+        - name: domain_userid
+          description: Snowplow domain_userid
+          in: query
+          type: string
+        - name: network_userid
+          description: Snowplow network_userid
+          in: query
+          type: string
+        - name: user_fingerprint
+          description: Snowplow user_fingerprint
+          in: query
+          type: string
+      security:
+        - ApiKeyAuth: []
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              placement:
+                type:
+                  - integer
+                  - 'null'
+        400:
+          $ref: '#/responses/BadRequest'
+        401:
+          $ref: '#/responses/Unauthorized'
+        404:
+          $ref: '#/responses/NotFound'
 
 securityDefinitions:
   ApiKeyAuth:

--- a/api/security/api-key-authorize.js
+++ b/api/security/api-key-authorize.js
@@ -80,17 +80,17 @@ function determineScopesAndType (auth) {
           api_key: auth
         }
       }).then((dbApiKey) => {
-      if (dbApiKey) {
-        resolve({
-          apiPatterns: dbApiKey.api_pattern,
-          isSuperAdmin: dbApiKey.type === 'super'
-        })
-      } else {
-        reject(new Error('API Key not found'))
-      }
-    }).catch(function (error) {
-      logger.error(error)
-      reject(error)
-    })
+        if (dbApiKey) {
+          resolve({
+            apiPatterns: dbApiKey.api_pattern,
+            isSuperAdmin: dbApiKey.type === 'super'
+          })
+        } else {
+          reject(new Error('API Key not found'))
+        }
+      }).catch(function (error) {
+        logger.error(error)
+        reject(error)
+      })
   })
 }

--- a/api/security/api-key-authorize.js
+++ b/api/security/api-key-authorize.js
@@ -13,6 +13,12 @@ module.exports = function authorize (request, response, next) {
         return
       }
 
+      // Allow placement requests regardless of apiPatterns
+      if (request.route.path === '/api/placement') {
+        next()
+        return
+      }
+
       if (!availableScopes || !availableScopes.length) {
         next(util.buildUnauthorizedError(error))
       } else {
@@ -74,17 +80,17 @@ function determineScopesAndType (auth) {
           api_key: auth
         }
       }).then((dbApiKey) => {
-        if (dbApiKey) {
-          resolve({
-            apiPatterns: dbApiKey.api_pattern,
-            isSuperAdmin: dbApiKey.type === 'super'
-          })
-        } else {
-          reject(new Error('API Key not found'))
-        }
-      }).catch(function (error) {
-        logger.error(error)
-        reject(error)
-      })
+      if (dbApiKey) {
+        resolve({
+          apiPatterns: dbApiKey.api_pattern,
+          isSuperAdmin: dbApiKey.type === 'super'
+        })
+      } else {
+        reject(new Error('API Key not found'))
+      }
+    }).catch(function (error) {
+      logger.error(error)
+      reject(error)
+    })
   })
 }

--- a/api/security/api-key-authorize.test.js
+++ b/api/security/api-key-authorize.test.js
@@ -27,6 +27,9 @@ describe('Api Key Authorizer', () => {
         query: {
           uri: 'http://some.uri.com'
         },
+        route: {
+          path: '/api/endpoint'
+        },
         headers: requestHeaders
       }
 
@@ -52,6 +55,38 @@ describe('Api Key Authorizer', () => {
         method: 'POST',
         body: {
           uri: 'http://some.uri.com'
+        },
+        route: {
+          path: '/api/endpoint'
+        },
+        headers: requestHeaders
+      }
+
+      const next = (error) => {
+        expect(error).toBeUndefined()
+        done()
+      }
+      jest.spyOn(ApiKey, 'findOne').mockImplementation(() => Promise.resolve(apiKey))
+
+      Authorizer(request, response, next)
+    })
+
+    test('should succeed on GET request for placement endpoint', done => {
+      const apiKey = {
+        api_key: 'some-api-key',
+        api_pattern: '.*'
+      }
+
+      const requestHeaders = {}
+      requestHeaders['x-api-key'] = apiKey.api_key
+
+      const request = {
+        method: 'POST',
+        body: {
+          uri: 'http://some.uri.com'
+        },
+        route: {
+          path: '/api/placement'
         },
         headers: requestHeaders
       }
@@ -130,6 +165,9 @@ describe('Api Key Authorizer', () => {
         query: {
           uri: 'http://some.uri.com'
         },
+        route: {
+          path: '/api/endpoint'
+        },
         headers: invalidRequestHeaders
       }
 
@@ -157,12 +195,44 @@ describe('Api Key Authorizer', () => {
         body: {
           uri: 'http://some.uri.com'
         },
+        route: {
+          path: '/api/endpoint'
+        },
         headers: invalidRequestHeaders
       }
 
       const next = (error) => {
         expect(error).toBeDefined()
         expect(error).toEqual(unauthorizedError)
+        done()
+      }
+      jest.spyOn(ApiKey, 'findOne').mockImplementation(() => Promise.resolve(apiKey))
+
+      Authorizer(request, response, next)
+    })
+
+    test('should succeed on GET request for placement endpoint', done => {
+      const apiKey = {
+        api_key: 'some-api-key',
+        api_pattern: null
+      }
+
+      const invalidRequestHeaders = {}
+      invalidRequestHeaders['x-api-key'] = apiKey.api_key
+
+      const request = {
+        method: 'GET',
+        query: {
+          uri: 'http://some.uri.com'
+        },
+        route: {
+          path: '/api/placement'
+        },
+        headers: invalidRequestHeaders
+      }
+
+      const next = (error) => {
+        expect(error).toBeUndefined()
         done()
       }
       jest.spyOn(ApiKey, 'findOne').mockImplementation(() => Promise.resolve(apiKey))

--- a/models/global-registry-client.test.js
+++ b/models/global-registry-client.test.js
@@ -114,7 +114,7 @@ describe('GlobalRegistryClient', () => {
         expect(client.placementBody('0987654321', placement)).toMatchObject({
           entity: {
             scale_of_belief: {
-              placement: 0,
+              placement: null,
               client_integration_id: '0987654321',
               'master_person:relationship': {
                 master_person: '0987654321',

--- a/models/placement.js
+++ b/models/placement.js
@@ -25,6 +25,7 @@ class Placement {
    */
   constructor (user) {
     this.user = user
+    this._placement = null
   }
 
   /**
@@ -35,13 +36,14 @@ class Placement {
     return sequelize()
       .query(Placement.QUERY, {replacements: {user_id: this.user.id}, type: sequelize().QueryTypes.SELECT})
       .then(results => {
-        self._placement = results[0].placement
+        let result = results[0]
+        self._placement = typeof result === 'undefined' ? null : result.placement
         return self
       })
   }
 
   get placement () {
-    return this._placement || 0
+    return this._placement
   }
 }
 

--- a/models/placement.test.js
+++ b/models/placement.test.js
@@ -17,9 +17,9 @@ describe('Placement', () => {
   })
 
   describe('placement getter', () => {
-    it('should return \'0\' by default', () => {
+    it('should return \'null\' by default', () => {
       let placement = new Placement({id: 234})
-      expect(placement.placement).toEqual(0)
+      expect(placement.placement).toEqual(null)
     })
 
     it('should return placement value', () => {

--- a/test/controllers/placement.test.js
+++ b/test/controllers/placement.test.js
@@ -1,0 +1,148 @@
+'use strict'
+
+jest.mock('../../models/placement')
+const controller = require('../../api/controllers/placement')
+const User = require('../../models/user')
+const Placement = require('../../models/placement')
+
+describe('Placement controller', () => {
+  let response
+  beforeEach(() => {
+    response = {
+      status: jest.fn(),
+      json: jest.fn()
+    }
+  })
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined()
+  })
+
+  describe('without query params', () => {
+    it('should return 400 Bad Request', (done) => {
+      expect.assertions(3)
+
+      response.json.mockImplementation(json => {
+        expect(json).toBeDefined()
+        expect(json.message).toEqual('Requires at least on query parameter.')
+        done()
+      })
+
+      response.status.mockImplementation(status => {
+        expect(status).toEqual(400)
+      })
+
+      controller.get({query: []}, response)
+    })
+  })
+
+  describe('user not found', () => {
+    it('should return 404 Not Found', (done) => {
+      expect.assertions(3)
+
+      response.json.mockImplementation(json => {
+        expect(json).toBeDefined()
+        expect(json.message).toEqual('Not Found')
+        done()
+      })
+
+      response.status.mockImplementation(status => {
+        expect(status).toEqual(404)
+      })
+
+      jest.spyOn(User, 'findOne').mockResolvedValue(null)
+
+      controller.get({query: {mcid: '1234'}}, response)
+    })
+  })
+
+  describe('error finding user', () => {
+    it('should return 400 error', (done) => {
+      expect.assertions(3)
+
+      response.json.mockImplementation(json => {
+        expect(json).toBeDefined()
+        expect(json.message).toEqual('error message')
+        done()
+      })
+
+      response.status.mockImplementation(status => {
+        expect(status).toEqual(400)
+      })
+
+      jest.spyOn(User, 'findOne').mockRejectedValue(new Error('error message'))
+
+      controller.get({query: {mcid: '1234'}}, response)
+    })
+  })
+
+  describe('user without placement', () => {
+    it('should return null placement value', (done) => {
+      expect.assertions(2)
+
+      response.json.mockImplementation(json => {
+        expect(json).toBeDefined()
+        expect(json).toEqual({placement: null})
+        done()
+      })
+
+      jest.spyOn(User, 'findOne').mockResolvedValue({id: 2345})
+
+      Placement.mockImplementation(() => {
+        return {
+          calculate: jest.fn().mockResolvedValue({placement: null})
+        }
+      })
+
+      controller.get({query: {mcid: '1234'}}, response)
+    })
+  })
+
+  describe('error calculating placement', () => {
+    it('should return 400 error', (done) => {
+      expect.assertions(3)
+
+      response.json.mockImplementation(json => {
+        expect(json).toBeDefined()
+        expect(json.message).toEqual('some error')
+        done()
+      })
+
+      response.status.mockImplementation(status => {
+        expect(status).toEqual(400)
+      })
+
+      jest.spyOn(User, 'findOne').mockResolvedValue({id: 2345})
+
+      Placement.mockImplementation(() => {
+        return {
+          calculate: jest.fn().mockRejectedValue(new Error('some error'))
+        }
+      })
+
+      controller.get({query: {mcid: '1234'}}, response)
+    })
+  })
+
+  describe('user with placement', () => {
+    it('should return placement value', (done) => {
+      expect.assertions(2)
+
+      response.json.mockImplementation(json => {
+        expect(json).toBeDefined()
+        expect(json).toEqual({placement: 7})
+        done()
+      })
+
+      jest.spyOn(User, 'findOne').mockResolvedValue({id: 2345})
+
+      Placement.mockImplementation(() => {
+        return {
+          calculate: jest.fn().mockResolvedValue({placement: 7})
+        }
+      })
+
+      controller.get({query: {mcid: '1234'}}, response)
+    })
+  })
+})


### PR DESCRIPTION
Add placement API endpoint. Allows anyone with a valid api token to query based on one or more user fields.
Default placement to null to differentiate between someone at 0 placement and not placed.