### PR TITLE
Fix Identity Stitcher

### DIFF
--- a/models/identity-stitcher.js
+++ b/models/identity-stitcher.js
@@ -218,7 +218,7 @@ const isSameSame = (user, other) => {
   if (user.has_device_idfa && other.has_device_idfa && matches['device_idfa'].length === 0) return false
 
   // If at least 2 fields match, it's the same user
-  if (sumBy(toPairs(matches), pair => { return pair[1] > 0 ? 1 : 0 }) >= 2) return true
+  if (sumBy(toPairs(matches), pair => { return pair[1].length > 0 ? 1 : 0 }) >= 2) return true
 
   return false
 }


### PR DESCRIPTION
Debugging database issue let to finding that the identity stitcher wasn't working properly when it didn't match by gr_master_person_id, sso_guid or device_idfa.
It was always creating a new user if those fields didn't match, resulting in a lot of duplicate users in the database which should of been merged.

This fixes the issue by correctly looking at the number of attribute matches instead of accidentally comparing arrays.

Debugging also showed DELETE queries takins a while to execute. This has been simplified to a single DELETE from users query.