### PR TITLE
KMA-56 - Send placement to ACS

### DIFF
--- a/config/adobe-campaign.js
+++ b/config/adobe-campaign.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const AdobeCampaignClient = require('../models/adobe-campaign-client')
+
+module.exports = new AdobeCampaignClient(
+  process.env['ACS_URL'],
+  process.env['ACS_API_KEY'],
+  process.env['ACS_JWT'],
+  process.env['ACS_CLIENT_SECRET'])

--- a/kinesis/campaign.js
+++ b/kinesis/campaign.js
@@ -1,0 +1,75 @@
+'use strict'
+
+const rollbar = require('../config/rollbar')
+const AdobeCampaign = require('../config/adobe-campaign')
+const {forEach} = require('lodash')
+const ACCESS_TOKEN = 'scale-of-belief-lambda-campaign-access-token'
+
+module.exports.handler = rollbar.lambdaHandler((lambdaEvent, lambdaContext, lambdaCallback) => {
+  const placement = lambdaEvent.placement
+  const grMasterPersonId = lambdaEvent.grMasterPersonId
+  const email = lambdaEvent.email
+
+  const asyncHandler = async () => {
+    let accessToken = await retrieveAccessToken()
+
+    if (accessToken instanceof Error) {
+      throw new Error(accessToken)
+    }
+    let matchedUsers = await AdobeCampaign.retrieveCampaignUser(email, grMasterPersonId, accessToken)
+
+    let promises = []
+    forEach(matchedUsers, (user) => {
+      promises.push(AdobeCampaign.updateCampaignUserPlacement(user['PKey'], placement.placement, accessToken))
+    })
+
+    return Promise.all(promises).then((results) => {
+      return Promise.resolve(`Successfully sent placement data for ${results.length} matched users to Adobe Campaign`)
+    }).catch((error) => {
+      return Promise.reject(error)
+    })
+  }
+
+  const retrieveAccessToken = () => {
+    return new Promise((resolve, reject) => {
+      const redis = require('redis')
+      const redisClient = redis.createClient(process.env.REDIS_PORT_6379_TCP_ADDR_PORT, process.env.REDIS_PORT_6379_TCP_ADDR)
+
+      redisClient.on('error', (error) => {
+        rollbar.warn(`Error connecting to Redis: ${error}`)
+        AdobeCampaign.retrieveAccessToken().then((accessToken) => {
+          redisClient.quit()
+          resolve(accessToken)
+        }).catch((error) => {
+          redisClient.quit()
+          reject(error)
+        })
+      })
+
+      redisClient.get(ACCESS_TOKEN, (error, response) => {
+        if (error) {
+          rollbar.warn(`Error retrieving ACCESS_TOKEN: ${error}`)
+          redisClient.quit()
+        } else if (response) {
+          redisClient.quit()
+          resolve(response)
+        }
+
+        AdobeCampaign.retrieveAccessToken().then((accessToken) => {
+          redisClient.quit()
+          resolve(accessToken)
+        }).catch((error) => {
+          redisClient.quit()
+          reject(error)
+        })
+      })
+    })
+  }
+
+  asyncHandler().then((message) => {
+    lambdaCallback(null, message)
+  }).catch((error) => {
+    rollbar.error('Something went wrong while sending the placement to Campaign: ' + error)
+    lambdaCallback('Failed to send placement to Campaign: ' + error)
+  })
+})

--- a/kinesis/campaign.js
+++ b/kinesis/campaign.js
@@ -6,9 +6,11 @@ const {forEach} = require('lodash')
 const ACCESS_TOKEN = 'scale-of-belief-lambda-campaign-access-token'
 
 module.exports.handler = rollbar.lambdaHandler((lambdaEvent, lambdaContext, lambdaCallback) => {
-  const placement = lambdaEvent.placement
-  const grMasterPersonId = lambdaEvent.grMasterPersonId
-  const email = lambdaEvent.email
+  let message = lambdaEvent.Records[0].Sns.Message
+  message = JSON.parse(message)
+  const placement = message.placement
+  const grMasterPersonId = message.grMasterPersonId
+  const email = message.email
 
   const asyncHandler = async () => {
     let accessToken = await retrieveAccessToken()

--- a/kinesis/campaign.js
+++ b/kinesis/campaign.js
@@ -21,7 +21,7 @@ module.exports.handler = rollbar.lambdaHandler((lambdaEvent, lambdaContext, lamb
 
     let promises = []
     forEach(matchedUsers, (user) => {
-      promises.push(AdobeCampaign.updateCampaignUserPlacement(user['PKey'], placement.placement, accessToken))
+      promises.push(AdobeCampaign.updateCampaignUserPlacement(user['PKey'], placement, accessToken))
     })
 
     return Promise.all(promises).then((results) => {

--- a/kinesis/campaign.js
+++ b/kinesis/campaign.js
@@ -10,7 +10,6 @@ module.exports.handler = rollbar.lambdaHandler((lambdaEvent, lambdaContext, lamb
   message = JSON.parse(message)
   const placement = message.placement
   const grMasterPersonId = message.grMasterPersonId
-  const email = message.email
 
   const asyncHandler = async () => {
     let accessToken = await retrieveAccessToken()
@@ -18,7 +17,7 @@ module.exports.handler = rollbar.lambdaHandler((lambdaEvent, lambdaContext, lamb
     if (accessToken instanceof Error) {
       throw new Error(accessToken)
     }
-    let matchedUsers = await AdobeCampaign.retrieveCampaignUser(email, grMasterPersonId, accessToken)
+    let matchedUsers = await AdobeCampaign.retrieveCampaignUser(grMasterPersonId, accessToken)
 
     let promises = []
     forEach(matchedUsers, (user) => {

--- a/kinesis/placement.js
+++ b/kinesis/placement.js
@@ -3,9 +3,10 @@
 const rollbar = require('../config/rollbar')
 const logger = require('../config/logger')
 const {forEach, chunk} = require('lodash')
-// const Placement = require('../models/placement')
+const Placement = require('../models/placement')
 // const GlobalRegistry = require('../config/global-registry')
 const promiseRetry = require('promise-retry')
+const AWS = require('aws-sdk')
 
 module.exports.handler = rollbar.lambdaHandler((lambdaEvent, lambdaContext, lambdaCallback) => {
   const sequelize = require('../config/sequelize')
@@ -46,10 +47,29 @@ module.exports.handler = rollbar.lambdaHandler((lambdaEvent, lambdaContext, lamb
                   // IdentityStitcher returns a saved user, but we still need to save the event
                   event.replace().then(event => {
                     // If the user has master_person identities and current event is scored, calculate placement
-                    // if (user.has_gr_master_person_id) {
-                    //   event.isScored().then(isScored => {
-                    //     if (isScored) {
-                    //       new Placement(user).calculate().then(placement => {
+                    if (user.has_gr_master_person_id) {
+                      event.isScored().then(isScored => {
+                        if (isScored) {
+                          new Placement(user).calculate().then(placement => {
+                            const sns = new AWS.SNS({ region: 'us-east-1' })
+                            const payload = {
+                              placement: placement,
+                              grMasterPersonId: user.gr_master_person_id
+                            }
+                            const params = {
+                              Message: JSON.stringify(payload),
+                              TopicArn: process.env.SNS_TOPIC_ARN
+                            }
+
+                            sns.publish(params, (error, data) => {
+                              if (error) {
+                                rollbar.error(error, error.stack)
+                                resolve(error)
+                              }
+                              if (data) {
+                                resolve(event)
+                              }
+                            })
                     //         // Update Global Registry
                     //         GlobalRegistry.updatePlacement(placement).then(() => {
                     //           // Resolve this event
@@ -61,16 +81,16 @@ module.exports.handler = rollbar.lambdaHandler((lambdaEvent, lambdaContext, lamb
                     //       }, error => {
                     //         rollbar.error(error, {record: record})
                     //         resolve(error)
-                    //       })
-                    //     } else {
-                    //       // Event isn't scored, resolve it
-                    //       resolve(event)
-                    //     }
-                    //   })
-                    // } else {
-                    // Resolve this event
-                    resolve(event)
-                    // }
+                          })
+                        } else {
+                          // Event isn't scored, resolve it
+                          resolve(event)
+                        }
+                      })
+                    } else {
+                      // Resolve this event
+                      resolve(event)
+                    }
                   }, error => {
                     rollbar.error('event.save() error', error, {record: record})
                     resolve(error)

--- a/kinesis/placement.js
+++ b/kinesis/placement.js
@@ -54,7 +54,7 @@ module.exports.handler = rollbar.lambdaHandler((lambdaEvent, lambdaContext, lamb
                             const sns = new AWS.SNS({ region: 'us-east-1' })
                             const payload = {
                               placement: placement.placement,
-                              grMasterPersonId: user.gr_master_person_id
+                              grMasterPersonIds: user.gr_master_person_id
                             }
                             const params = {
                               Message: JSON.stringify(payload),

--- a/kinesis/placement.js
+++ b/kinesis/placement.js
@@ -53,7 +53,7 @@ module.exports.handler = rollbar.lambdaHandler((lambdaEvent, lambdaContext, lamb
                           new Placement(user).calculate().then(placement => {
                             const sns = new AWS.SNS({ region: 'us-east-1' })
                             const payload = {
-                              placement: placement,
+                              placement: placement.placement,
                               grMasterPersonId: user.gr_master_person_id
                             }
                             const params = {

--- a/models/adobe-campaign-client.js
+++ b/models/adobe-campaign-client.js
@@ -1,0 +1,133 @@
+'use strict'
+
+const request = require('request')
+const {forEach} = require('lodash')
+const redis = require('redis')
+
+const ACCESS_TOKEN = 'scale-of-belief-lambda-campaign-access-token'
+
+class AdobeCampaignClient {
+  constructor (baseUrl, apiKey, jwt, clientSecret) {
+    this.baseUrl = baseUrl
+    this.apiKey = apiKey
+    this.jwt = jwt
+    this.clientSecret = clientSecret
+  }
+
+  retrieveAccessToken () {
+    let options = {
+      url: 'https://ims-na1.adobelogin.com/ims/exchange/jwt/',
+      formData: this.accessTokenBody(),
+      headers: {
+        'Cache-Control': 'no-cache'
+      }
+    }
+    return new Promise((resolve, reject) => {
+      request.post(options, (err, response, body) => {
+        if (err) {
+          reject(err)
+        }
+
+        if (response.statusCode === 200) {
+          const redisClient = redis.createClient(process.env.REDIS_PORT_6379_TCP_ADDR_PORT, process.env.REDIS_PORT_6379_TCP_ADDR)
+          redisClient.on('error', (error) => {
+            redisClient.quit()
+            // We want the system to be able to keep sending updates to ACS even if Redis is having issues
+            console.warn('Failed to connect to Redis for updating the access token', error)
+          })
+
+          const accessToken = JSON.parse(body).access_token
+
+          redisClient.set(ACCESS_TOKEN, accessToken)
+          resolve(accessToken)
+        } else {
+          reject(new Error('Failed to retrieve access token: ' + body))
+        }
+      })
+    })
+  }
+
+  accessTokenBody () {
+    return {
+      client_id: this.apiKey,
+      client_secret: this.clientSecret,
+      jwt_token: this.jwt
+    }
+  }
+
+  /**
+   * Returns all users with the given email address and GR master person ID (cusGlobalID).
+   */
+  retrieveCampaignUser (email, grMasterPersonId, accessToken) {
+    let options = {
+      url: `${this.baseUrl}/profileAndServicesExt/profile/byEmail?email=${email}`,
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'X-Api-Key': this.apiKey,
+        'Cache-Control': 'no-cache'
+      }
+    }
+
+    return new Promise((resolve, reject) => {
+      request.get(options, async (err, response, body) => {
+        if (err) {
+          reject(err)
+        } else if (response.statusCode === 401) {
+          let newAccessToken = await this.retrieveAccessToken()
+          resolve(this.retrieveCampaignUser(email, grMasterPersonId, newAccessToken))
+        } else if (response.statusCode >= 400) {
+          reject(new Error('Something went wrong with your request: ' + body))
+        }
+
+        resolve(this.filterUsers(JSON.parse(body).content, grMasterPersonId))
+      })
+    })
+  }
+
+  filterUsers (users, grMasterPersonId) {
+    let filteredUsers = []
+    forEach(users, (user) => {
+      if (user['cusGlobalID'] && user['cusGlobalID'] === grMasterPersonId) {
+        filteredUsers.push(user)
+      }
+    })
+
+    return filteredUsers
+  }
+
+  updateCampaignUserPlacement (pkey, placement, accessToken) {
+    let options = {
+      url: `${this.baseUrl}/profileAndServicesExt/profile/${pkey}`,
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'X-Api-Key': this.apiKey,
+        'Cache-Control': 'no-cache',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(this.placementBody(placement))
+    }
+
+    return new Promise((resolve, reject) => {
+      request.patch(options, async (err, response, body) => {
+        if (err) {
+          reject(err)
+        } else if (response.statusCode === 401) {
+          let newAccessToken = await this.retrieveAccessToken()
+          resolve(this.updateCampaignUserPlacement(pkey, placement, newAccessToken))
+        } else if (response.statusCode >= 400) {
+          reject(new Error('Something went wrong with your request: ' + body))
+        }
+
+        resolve(JSON.parse(body))
+      })
+    })
+  }
+
+  placementBody (placement) {
+    return {
+      cusPlacement: placement
+    }
+  }
+}
+
+module.exports = AdobeCampaignClient

--- a/models/adobe-campaign-client.js
+++ b/models/adobe-campaign-client.js
@@ -38,6 +38,7 @@ class AdobeCampaignClient {
           const accessToken = JSON.parse(body).access_token
 
           redisClient.set(ACCESS_TOKEN, accessToken)
+          redisClient.quit()
           resolve(accessToken)
         } else {
           reject(new Error('Failed to retrieve access token: ' + body))

--- a/models/adobe-campaign-client.test.js
+++ b/models/adobe-campaign-client.test.js
@@ -114,10 +114,9 @@ describe('AdobeCampaignClient', () => {
     const accessToken = 'access-token'
 
     it('should retrieve one campaign user', done => {
-      const email = 'test@test.com'
       const grMasterPersonId = 'gr-id'
       const options = {
-        url: `${exampleUri}/profileAndServicesExt/profile/byEmail?email=${email}`,
+        url: `${exampleUri}/profileAndServicesExt/profile/byGlobalid?globalId_parameter=${grMasterPersonId}`,
         headers: {
           'Authorization': `Bearer ${accessToken}`,
           'X-Api-Key': exampleApiKey,
@@ -133,8 +132,8 @@ describe('AdobeCampaignClient', () => {
           }
         ],
         count: {
-          // note: in my testing, the actual response has profile//byEmail rather than profile/byEmail
-          href: `${exampleUri}/profileAndServicesExt/profile/byEmail/_count?email=${email}&_lineStart=some-pkey`,
+          // note: in my testing, the actual response has profile//byGlobalid rather than profile/byGlobalid
+          href: `${exampleUri}/profileAndServicesExt/profile/byGlobalid/_count?globalId_parameter=${grMasterPersonId}&_lineStart=some-pkey`,
           value: 1
         },
         serverSidePagination: false
@@ -144,7 +143,7 @@ describe('AdobeCampaignClient', () => {
         callback(null, mockResponse, JSON.stringify(mockBody))
       })
 
-      client.retrieveCampaignUser(email, grMasterPersonId, accessToken).then((users) => {
+      client.retrieveCampaignUser(grMasterPersonId, accessToken).then((users) => {
         expect(users).toBeDefined()
         expect(users.length).toEqual(1)
         expect(requestMock).toHaveBeenCalledWith(options, expect.anything())
@@ -154,24 +153,21 @@ describe('AdobeCampaignClient', () => {
     })
 
     it('should retrieve multiple campaign users', done => {
-      const email = 'test@test.com'
       const grMasterPersonId = 'gr-id'
       const mockResponse = { statusCode: 200 }
       const mockBody = {
         content: [
           {
             PKey: 'pkey',
-            cusGlobalID: grMasterPersonId,
-            email: email
+            cusGlobalID: grMasterPersonId
           },
           {
             PKey: 'pkey2',
-            cusGlobalID: grMasterPersonId,
-            email: email
+            cusGlobalID: grMasterPersonId
           }
         ],
         count: {
-          href: `${exampleUri}/profileAndServicesExt/profile/byEmail/_count?email=${email}&_lineStart=some-pkey`,
+          href: `${exampleUri}/profileAndServicesExt/profile/byGlobalid/_count?globalId_parameter=${grMasterPersonId}&_lineStart=some-pkey`,
           value: 2
         },
         serverSidePagination: false
@@ -181,7 +177,7 @@ describe('AdobeCampaignClient', () => {
         callback(null, mockResponse, JSON.stringify(mockBody))
       })
 
-      client.retrieveCampaignUser(email, grMasterPersonId, accessToken).then((users) => {
+      client.retrieveCampaignUser(grMasterPersonId, accessToken).then((users) => {
         expect(users).toBeDefined()
         expect(users.length).toEqual(2)
         requestMock.mockReset()
@@ -190,13 +186,12 @@ describe('AdobeCampaignClient', () => {
     })
 
     it('should retrieve zero campaign users', done => {
-      const email = 'nobody@test.com'
       const grMasterPersonId = 'no-id'
       const mockResponse = { statusCode: 200 }
       const mockBody = {
         content: [],
         count: {
-          href: `${exampleUri}/profileAndServicesExt/profile/byEmail/_count?email=${email}&_lineStart=some-pkey`,
+          href: `${exampleUri}/profileAndServicesExt/profile/byGlobalid/_count?globalId_parameter=${grMasterPersonId}&_lineStart=some-pkey`,
           value: 0
         },
         serverSidePagination: false
@@ -206,7 +201,7 @@ describe('AdobeCampaignClient', () => {
         callback(null, mockResponse, JSON.stringify(mockBody))
       })
 
-      client.retrieveCampaignUser(email, grMasterPersonId, accessToken).then((users) => {
+      client.retrieveCampaignUser(grMasterPersonId, accessToken).then((users) => {
         expect(users).toBeDefined()
         expect(users.length).toEqual(0)
         requestMock.mockReset()
@@ -215,7 +210,6 @@ describe('AdobeCampaignClient', () => {
     })
 
     it('should request a new access token when ours is expired', done => {
-      const email = 'test@test.com'
       const grMasterPersonId = 'gr-id'
       const mockFirstResponse = { statusCode: 401 }
       const mockSecondResponse = { statusCode: 200 }
@@ -231,8 +225,8 @@ describe('AdobeCampaignClient', () => {
           }
         ],
         count: {
-          // note: in my testing, the actual response has profile//byEmail rather than profile/byEmail
-          href: `${exampleUri}/profileAndServicesExt/profile/byEmail/_count?email=${email}&_lineStart=some-pkey`,
+          // note: in my testing, the actual response has profile//byGlobalid rather than profile/byGlobalid
+          href: `${exampleUri}/profileAndServicesExt/profile/byGlobalid/_count?globalId_parameter=${grMasterPersonId}&_lineStart=some-pkey`,
           value: 1
         },
         serverSidePagination: false
@@ -256,7 +250,7 @@ describe('AdobeCampaignClient', () => {
         callback(null, mockResponse, JSON.stringify(mockBody))
       })
 
-      client.retrieveCampaignUser(email, grMasterPersonId, accessToken).then((users) => {
+      client.retrieveCampaignUser(grMasterPersonId, accessToken).then((users) => {
         expect(requestMock).toHaveBeenCalledTimes(2)
         expect(requestPostMock).toHaveBeenCalledTimes(1)
         expect(users).toBeDefined()
@@ -268,7 +262,6 @@ describe('AdobeCampaignClient', () => {
     })
 
     it('should fail to retrieve campaign users', done => {
-      const email = 'error@test.com'
       const grMasterPersonId = 'no-id'
       const mockResponse = { statusCode: 500 }
       const mockBody = {
@@ -280,7 +273,7 @@ describe('AdobeCampaignClient', () => {
         callback(null, mockResponse, JSON.stringify(mockBody))
       })
 
-      client.retrieveCampaignUser(email, grMasterPersonId, accessToken).then((users) => {
+      client.retrieveCampaignUser(grMasterPersonId, accessToken).then((users) => {
         requestMock.mockReset()
         done.fail()
       }).catch((error) => {
@@ -292,14 +285,13 @@ describe('AdobeCampaignClient', () => {
     })
 
     it('should get an error retrieving campaign users', done => {
-      const email = 'error@test.com'
       const grMasterPersonId = 'no-id'
 
       const requestMock = jest.spyOn(request, 'get').mockImplementation((options, callback) => {
         callback(new Error('Some Error!'), null, null)
       })
 
-      client.retrieveCampaignUser(email, grMasterPersonId, accessToken).then((users) => {
+      client.retrieveCampaignUser(grMasterPersonId, accessToken).then((users) => {
         requestMock.mockReset()
         done.fail()
       }).catch((error) => {
@@ -308,50 +300,6 @@ describe('AdobeCampaignClient', () => {
         expect(error.message).toEqual('Some Error!')
         done()
       })
-    })
-  })
-
-  describe('filterUsers()', () => {
-    const client = new AdobeCampaignClient(exampleUri, exampleApiKey, exampleJwt, exampleSecret)
-    const grMasterPersonId = 'gr-id'
-
-    let allUsers = [
-      {
-        email: 'test@test.com',
-        cusGlobalID: grMasterPersonId,
-        cusSSOGUID: 'some-guid'
-      }
-    ]
-
-    it('should return all of the users', () => {
-      const filteredUsers = client.filterUsers(allUsers, grMasterPersonId)
-      expect(filteredUsers).toBeDefined()
-      expect(filteredUsers.length).toEqual(1)
-      expect(filteredUsers).toEqual(allUsers)
-    })
-
-    it('should return one of the users', () => {
-      allUsers.push({
-        email: 'test@test.com',
-        cusGlobalID: 'other-gr-id',
-        cusSSOGUID: 'other-guid'
-      })
-      const filteredUsers = client.filterUsers(allUsers, grMasterPersonId)
-      expect(filteredUsers).toBeDefined()
-      expect(filteredUsers.length).toEqual(1)
-      expect(filteredUsers[0]).toEqual(
-        {
-          email: 'test@test.com',
-          cusGlobalID: grMasterPersonId,
-          cusSSOGUID: 'some-guid'
-        }
-      )
-    })
-
-    it('should return zero of the users', () => {
-      const filteredUsers = client.filterUsers(allUsers, 'third-gr-id')
-      expect(filteredUsers).toBeDefined()
-      expect(filteredUsers.length).toEqual(0)
     })
   })
 

--- a/models/adobe-campaign-client.test.js
+++ b/models/adobe-campaign-client.test.js
@@ -1,0 +1,468 @@
+'use strict'
+
+const AdobeCampaignClient = require('./adobe-campaign-client')
+const request = require('request')
+
+describe('AdobeCampaignClient', () => {
+  it('should be defined', () => {
+    expect(AdobeCampaignClient).toBeDefined()
+  })
+
+  const exampleUri = 'https://example.com'
+  const exampleApiKey = 'abc123'
+  const exampleJwt = 'jwt.123:45a'
+  const exampleSecret = 'secrets'
+
+  describe('constructor', () => {
+    it('should set baseUrl, apiKey, jwt, and clientSecret', () => {
+      const client = new AdobeCampaignClient(exampleUri, exampleApiKey, exampleJwt, exampleSecret)
+
+      expect(client.baseUrl).toEqual(exampleUri)
+      expect(client.apiKey).toEqual(exampleApiKey)
+      expect(client.jwt).toEqual(exampleJwt)
+      expect(client.clientSecret).toEqual(exampleSecret)
+    })
+  })
+
+  describe('retrieveAccessToken()', () => {
+    const client = new AdobeCampaignClient(exampleUri, exampleApiKey, exampleJwt, exampleSecret)
+
+    it('should retrieve a new access token', done => {
+      const options = {
+        url: 'https://ims-na1.adobelogin.com/ims/exchange/jwt/',
+        formData: {
+          client_id: exampleApiKey,
+          client_secret: exampleSecret,
+          jwt_token: exampleJwt
+        },
+        headers: {
+          'Cache-Control': 'no-cache'
+        }
+      }
+      const mockResponse = { statusCode: 200 }
+      const mockBody = {
+        token_type: 'bearer',
+        access_token: 'access-token',
+        expires_in: 86399992
+      }
+
+      const requestMock = jest.spyOn(request, 'post').mockImplementation((options, callback) => {
+        callback(null, mockResponse, JSON.stringify(mockBody))
+      })
+
+      client.retrieveAccessToken().then((accessToken) => {
+        expect(requestMock).toHaveBeenCalledWith(options, expect.anything())
+        expect(accessToken).toEqual('access-token')
+        requestMock.mockReset()
+        done()
+      })
+    })
+
+    it('should fail to retrieve a new access token', done => {
+      const mockResponse = { statusCode: 400 }
+      const mockBody = {
+        error_description: 'Could not match JWT signature to any of the bindings',
+        error: 'invalid_token'}
+
+      const requestMock = jest.spyOn(request, 'post').mockImplementation((options, callback) => {
+        callback(null, mockResponse, JSON.stringify(mockBody))
+      })
+
+      client.retrieveAccessToken().then(() => {
+        requestMock.mockReset()
+        done.fail()
+      }).catch((err) => {
+        expect(err).toBeDefined()
+        expect(err.message).toEqual(
+          'Failed to retrieve access token: {"error_description":"Could not match JWT signature to any of the bindings",' +
+          '"error":"invalid_token"}')
+        requestMock.mockReset()
+        done()
+      })
+    })
+
+    it('should have an error retrieving a new access token', done => {
+      const requestMock = jest.spyOn(request, 'post').mockImplementation((options, callback) => {
+        callback(new Error('Internal Server Error'), null, null)
+      })
+
+      client.retrieveAccessToken().then(() => {
+        requestMock.mockReset()
+        done.fail()
+      }).catch((err) => {
+        expect(err).toBeDefined()
+        expect(err.message).toEqual('Internal Server Error')
+        requestMock.mockReset()
+        done()
+      })
+    })
+  })
+
+  describe('accessTokenBody()', () => {
+    it('should create an access token POST request body', () => {
+      const client = new AdobeCampaignClient(exampleUri, exampleApiKey, exampleJwt, exampleSecret)
+      const accessTokenBody = client.accessTokenBody()
+      expect(accessTokenBody).toBeDefined()
+      expect(accessTokenBody.client_id).toEqual(exampleApiKey)
+      expect(accessTokenBody.client_secret).toEqual(exampleSecret)
+      expect(accessTokenBody.jwt_token).toEqual(exampleJwt)
+    })
+  })
+
+  describe('retrieveCampaignUser()', () => {
+    const client = new AdobeCampaignClient(exampleUri, exampleApiKey, exampleJwt, exampleSecret)
+    const accessToken = 'access-token'
+
+    it('should retrieve one campaign user', done => {
+      const email = 'test@test.com'
+      const grMasterPersonId = 'gr-id'
+      const options = {
+        url: `${exampleUri}/profileAndServicesExt/profile/byEmail?email=${email}`,
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'X-Api-Key': exampleApiKey,
+          'Cache-Control': 'no-cache'
+        }
+      }
+      const mockResponse = { statusCode: 200 }
+      const mockBody = {
+        content: [
+          {
+            PKey: 'pkey',
+            cusGlobalID: grMasterPersonId
+          }
+        ],
+        count: {
+          // note: in my testing, the actual response has profile//byEmail rather than profile/byEmail
+          href: `${exampleUri}/profileAndServicesExt/profile/byEmail/_count?email=${email}&_lineStart=some-pkey`,
+          value: 1
+        },
+        serverSidePagination: false
+      }
+
+      const requestMock = jest.spyOn(request, 'get').mockImplementation((options, callback) => {
+        callback(null, mockResponse, JSON.stringify(mockBody))
+      })
+
+      client.retrieveCampaignUser(email, grMasterPersonId, accessToken).then((users) => {
+        expect(users).toBeDefined()
+        expect(users.length).toEqual(1)
+        expect(requestMock).toHaveBeenCalledWith(options, expect.anything())
+        requestMock.mockReset()
+        done()
+      })
+    })
+
+    it('should retrieve multiple campaign users', done => {
+      const email = 'test@test.com'
+      const grMasterPersonId = 'gr-id'
+      const mockResponse = { statusCode: 200 }
+      const mockBody = {
+        content: [
+          {
+            PKey: 'pkey',
+            cusGlobalID: grMasterPersonId,
+            email: email
+          },
+          {
+            PKey: 'pkey2',
+            cusGlobalID: grMasterPersonId,
+            email: email
+          }
+        ],
+        count: {
+          href: `${exampleUri}/profileAndServicesExt/profile/byEmail/_count?email=${email}&_lineStart=some-pkey`,
+          value: 2
+        },
+        serverSidePagination: false
+      }
+
+      const requestMock = jest.spyOn(request, 'get').mockImplementation((options, callback) => {
+        callback(null, mockResponse, JSON.stringify(mockBody))
+      })
+
+      client.retrieveCampaignUser(email, grMasterPersonId, accessToken).then((users) => {
+        expect(users).toBeDefined()
+        expect(users.length).toEqual(2)
+        requestMock.mockReset()
+        done()
+      })
+    })
+
+    it('should retrieve zero campaign users', done => {
+      const email = 'nobody@test.com'
+      const grMasterPersonId = 'no-id'
+      const mockResponse = { statusCode: 200 }
+      const mockBody = {
+        content: [],
+        count: {
+          href: `${exampleUri}/profileAndServicesExt/profile/byEmail/_count?email=${email}&_lineStart=some-pkey`,
+          value: 0
+        },
+        serverSidePagination: false
+      }
+
+      const requestMock = jest.spyOn(request, 'get').mockImplementation((options, callback) => {
+        callback(null, mockResponse, JSON.stringify(mockBody))
+      })
+
+      client.retrieveCampaignUser(email, grMasterPersonId, accessToken).then((users) => {
+        expect(users).toBeDefined()
+        expect(users.length).toEqual(0)
+        requestMock.mockReset()
+        done()
+      })
+    })
+
+    it('should request a new access token when ours is expired', done => {
+      const email = 'test@test.com'
+      const grMasterPersonId = 'gr-id'
+      const mockFirstResponse = { statusCode: 401 }
+      const mockSecondResponse = { statusCode: 200 }
+      const mockFirstBody = {
+        error_code: '401013',
+        message: 'Oauth token is not valid'
+      }
+      const mockSecondBody = {
+        content: [
+          {
+            PKey: 'pkey',
+            cusGlobalID: grMasterPersonId
+          }
+        ],
+        count: {
+          // note: in my testing, the actual response has profile//byEmail rather than profile/byEmail
+          href: `${exampleUri}/profileAndServicesExt/profile/byEmail/_count?email=${email}&_lineStart=some-pkey`,
+          value: 1
+        },
+        serverSidePagination: false
+      }
+
+      const requestMock = jest.spyOn(request, 'get')
+        .mockImplementationOnce((options, callback) => {
+          callback(null, mockFirstResponse, JSON.stringify(mockFirstBody))
+        })
+        .mockImplementationOnce((options, callback) => {
+          callback(null, mockSecondResponse, JSON.stringify(mockSecondBody))
+        })
+
+      const requestPostMock = jest.spyOn(request, 'post').mockImplementation((options, callback) => {
+        const mockResponse = { statusCode: 200 }
+        const mockBody = {
+          token_type: 'bearer',
+          access_token: 'new-access-token',
+          expires_in: 86399992
+        }
+        callback(null, mockResponse, JSON.stringify(mockBody))
+      })
+
+      client.retrieveCampaignUser(email, grMasterPersonId, accessToken).then((users) => {
+        expect(requestMock).toHaveBeenCalledTimes(2)
+        expect(requestPostMock).toHaveBeenCalledTimes(1)
+        expect(users).toBeDefined()
+        expect(users.length).toEqual(1)
+        requestMock.mockReset()
+        requestPostMock.mockReset()
+        done()
+      })
+    })
+
+    it('should fail to retrieve campaign users', done => {
+      const email = 'error@test.com'
+      const grMasterPersonId = 'no-id'
+      const mockResponse = { statusCode: 500 }
+      const mockBody = {
+        error_code: '1',
+        message: 'Internal Server Error'
+      }
+
+      const requestMock = jest.spyOn(request, 'get').mockImplementation((options, callback) => {
+        callback(null, mockResponse, JSON.stringify(mockBody))
+      })
+
+      client.retrieveCampaignUser(email, grMasterPersonId, accessToken).then((users) => {
+        requestMock.mockReset()
+        done.fail()
+      }).catch((error) => {
+        expect(error).toBeDefined()
+        expect(error.message).toEqual('Something went wrong with your request: ' + JSON.stringify(mockBody))
+        requestMock.mockReset()
+        done()
+      })
+    })
+
+    it('should get an error retrieving campaign users', done => {
+      const email = 'error@test.com'
+      const grMasterPersonId = 'no-id'
+
+      const requestMock = jest.spyOn(request, 'get').mockImplementation((options, callback) => {
+        callback(new Error('Some Error!'), null, null)
+      })
+
+      client.retrieveCampaignUser(email, grMasterPersonId, accessToken).then((users) => {
+        requestMock.mockReset()
+        done.fail()
+      }).catch((error) => {
+        requestMock.mockReset()
+        expect(error).toBeDefined()
+        expect(error.message).toEqual('Some Error!')
+        done()
+      })
+    })
+  })
+
+  describe('filterUsers()', () => {
+    const client = new AdobeCampaignClient(exampleUri, exampleApiKey, exampleJwt, exampleSecret)
+    const grMasterPersonId = 'gr-id'
+
+    let allUsers = [
+      {
+        email: 'test@test.com',
+        cusGlobalID: grMasterPersonId,
+        cusSSOGUID: 'some-guid'
+      }
+    ]
+
+    it('should return all of the users', () => {
+      const filteredUsers = client.filterUsers(allUsers, grMasterPersonId)
+      expect(filteredUsers).toBeDefined()
+      expect(filteredUsers.length).toEqual(1)
+      expect(filteredUsers).toEqual(allUsers)
+    })
+
+    it('should return one of the users', () => {
+      allUsers.push({
+        email: 'test@test.com',
+        cusGlobalID: 'other-gr-id',
+        cusSSOGUID: 'other-guid'
+      })
+      const filteredUsers = client.filterUsers(allUsers, grMasterPersonId)
+      expect(filteredUsers).toBeDefined()
+      expect(filteredUsers.length).toEqual(1)
+      expect(filteredUsers[0]).toEqual(
+        {
+          email: 'test@test.com',
+          cusGlobalID: grMasterPersonId,
+          cusSSOGUID: 'some-guid'
+        }
+      )
+    })
+
+    it('should return zero of the users', () => {
+      const filteredUsers = client.filterUsers(allUsers, 'third-gr-id')
+      expect(filteredUsers).toBeDefined()
+      expect(filteredUsers.length).toEqual(0)
+    })
+  })
+
+  describe('updateCampaignUserPlacement()', () => {
+    const client = new AdobeCampaignClient(exampleUri, exampleApiKey, exampleJwt, exampleSecret)
+    const pkey = 'pkey'
+    const accessToken = 'access-token'
+
+    it('should successfully send an update for the placement value', done => {
+      const options = {
+        url: `${exampleUri}/profileAndServicesExt/profile/${pkey}`,
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'X-Api-Key': exampleApiKey,
+          'Cache-Control': 'no-cache',
+          'Content-Type': 'application/json'
+        },
+        body: '{ "cusPlacement": "placement" }'
+      }
+      const mockResponse = { statusCode: 200 }
+      const mockBody = {
+        PKey: pkey,
+        href: options.url
+      }
+
+      const requestMock = jest.spyOn(request, 'patch').mockImplementation((options, callback) => {
+        callback(null, mockResponse, JSON.stringify(mockBody))
+      })
+
+      client.updateCampaignUserPlacement(pkey, 5, accessToken).then((response) => {
+        expect(response).toBeDefined()
+        expect(response).toEqual(mockBody)
+        requestMock.mockReset()
+        done()
+      })
+    })
+
+    it('should request a new access token when ours is expired', done => {
+      const mockFirstResponse = { statusCode: 401 }
+      const mockSecondResponse = { statusCode: 200 }
+      const mockFirstBody = {
+        error_code: '401013',
+        message: 'Oauth token is not valid'
+      }
+      const mockSecondBody = {
+        PKey: pkey,
+        href: `${exampleUri}/profileAndServicesExt/profile/${pkey}`
+      }
+
+      const requestMock = jest.spyOn(request, 'patch')
+        .mockImplementationOnce((options, callback) => {
+          callback(null, mockFirstResponse, JSON.stringify(mockFirstBody))
+        })
+        .mockImplementationOnce((options, callback) => {
+          callback(null, mockSecondResponse, JSON.stringify(mockSecondBody))
+        })
+
+      const requestPostMock = jest.spyOn(request, 'post').mockImplementation((options, callback) => {
+        const mockResponse = { statusCode: 200 }
+        const mockBody = {
+          token_type: 'bearer',
+          access_token: 'new-access-token',
+          expires_in: 86399992
+        }
+        callback(null, mockResponse, JSON.stringify(mockBody))
+      })
+
+      client.updateCampaignUserPlacement(pkey, 5, accessToken).then((response) => {
+        expect(requestMock).toHaveBeenCalledTimes(2)
+        expect(requestPostMock).toHaveBeenCalledTimes(1)
+        expect(response).toBeDefined()
+        expect(response).toEqual(mockSecondBody)
+        requestMock.mockReset()
+        requestPostMock.mockReset()
+        done()
+      })
+    })
+
+    it('should fail to send an update', done => {
+      const mockResponse = { statusCode: 500 }
+      const mockBody = 'BAS-010040 Cannot convert \'a\' (type text) to integer (8 bit) type (bAS-010011 Invalid value).'
+
+      const requestMock = jest.spyOn(request, 'patch').mockImplementation((options, callback) => {
+        callback(null, mockResponse, JSON.stringify(mockBody))
+      })
+
+      client.updateCampaignUserPlacement(pkey, 5, accessToken).then((response) => {
+        requestMock.mockReset()
+        done.fail()
+      }).catch((error) => {
+        expect(error).toBeDefined()
+        expect(error.message).toEqual(`Something went wrong with your request: "${mockBody}"`)
+        requestMock.mockReset()
+        done()
+      })
+    })
+
+    it('should get an error when sending an update', done => {
+      const requestMock = jest.spyOn(request, 'patch').mockImplementation((options, callback) => {
+        callback(new Error('Failed to send'), null, null)
+      })
+
+      client.updateCampaignUserPlacement(pkey, 5, accessToken).then((response) => {
+        requestMock.mockReset()
+        done.fail()
+      }).catch((error) => {
+        expect(error).toBeDefined()
+        expect(error.message).toEqual('Failed to send')
+        requestMock.mockReset()
+        done()
+      })
+    })
+  })
+})

--- a/serverless.yml
+++ b/serverless.yml
@@ -58,6 +58,8 @@ functions:
   campaign:
     handler: kinesis/campaign.handler
     timeout: 300
+    events:
+      - sns: ${env:SNS_TOPIC_ARN}
 
 package:
   exclude:

--- a/serverless.yml
+++ b/serverless.yml
@@ -55,6 +55,9 @@ functions:
     timeout: 300
     events:
       - schedule: rate(2 hours)
+  campaign:
+    handler: kinesis/campaign.handler
+    timeout: 300
 
 package:
   exclude:

--- a/serverless/environment.js
+++ b/serverless/environment.js
@@ -24,6 +24,10 @@ module.exports = () => {
     REDSHIFT_IAM_ROLE: process.env['REDSHIFT_IAM_ROLE'],
     REDSHIFT_S3_BUCKET: process.env['REDSHIFT_S3_BUCKET'],
     REDIS_PORT_6379_TCP_ADDR: process.env['REDIS_PORT_6379_TCP_ADDR'],
-    REDIS_PORT_6379_TCP_ADDR_PORT: process.env['REDIS_PORT_6379_TCP_ADDR_PORT'] || 6379
+    REDIS_PORT_6379_TCP_ADDR_PORT: process.env['REDIS_PORT_6379_TCP_ADDR_PORT'] || 6379,
+    ACS_JWT: process.env['ACS_JWT'] || 'jwt',
+    ACS_CLIENT_SECRET: process.env['ACS_CLIENT_SECRET'] || 'secret',
+    ACS_API_KEY: process.env['ACS_API_KEY'] || '',
+    ACS_URL: process.env['ACS_URL'] || 'https://mc.adobe.io/cru/campaign/'
   }
 }

--- a/serverless/environment.js
+++ b/serverless/environment.js
@@ -28,6 +28,7 @@ module.exports = () => {
     ACS_JWT: process.env['ACS_JWT'] || 'jwt',
     ACS_CLIENT_SECRET: process.env['ACS_CLIENT_SECRET'] || 'secret',
     ACS_API_KEY: process.env['ACS_API_KEY'] || '',
-    ACS_URL: process.env['ACS_URL'] || 'https://mc.adobe.io/cru/campaign/'
+    ACS_URL: process.env['ACS_URL'] || 'https://mc.adobe.io/cru/campaign/',
+    SNS_TOPIC_ARN: process.env['SNS_TOPIC_ARN'] || ''
   }
 }


### PR DESCRIPTION
This PR will use an SNS queue to send placement data from the placement lambda to the campaign lambda, which will then send it to Adobe Campaign Standard.

[Jira](https://jira.cru.org/browse/KMA-56)