### PR TITLE
KMA-49 - materialized view

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,5 @@ after_success:
   - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
 env:
   - DB_ENV_POSTGRESQL_DB=scale_of_belief DB_ENV_POSTGRESQL_USER=postgres
+addons:
+  postgresql: "9.4"

--- a/config/sequelize.js
+++ b/config/sequelize.js
@@ -8,6 +8,7 @@ const requiredModels = [
   '../models/event',
   '../models/user',
   '../models/score',
+  '../models/unscored',
   '../models/api-user',
   '../models/api-key',
   './papertrail'

--- a/db/migrate/20180906080400-create-materialized-view-unscored.js
+++ b/db/migrate/20180906080400-create-materialized-view-unscored.js
@@ -1,0 +1,21 @@
+'use strict'
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    // Create the materialized view "unscored"
+    return queryInterface.sequelize.query(
+      'CREATE MATERIALIZED VIEW unscored AS ' +
+      '(SELECT DISTINCT events.uri ' +
+      'FROM events LEFT JOIN scores USING (uri) ' +
+      'WHERE scores.uri IS NULL) ' +
+      'WITH DATA')
+      // Add a unique index on the primary key "uri"
+      .then(() => queryInterface.addIndex('unscored', {fields: ['uri'], unique: true, name: 'idx_unscored_uri'}))
+      // Add a prefix index on "uri"
+      .then(() => queryInterface.addIndex('unscored', {fields: ['uri'], operator: 'text_pattern_ops', name: 'idx_unscored_uri_prefix'}))
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeIndex('unscored', 'idx_unscored_uri')
+      .then(queryInterface.removeIndex('unscored', 'idx_unscored_uri_prefix'))
+      .then(() => queryInterface.sequelize.query('DROP MATERIALIZED VIEW IF EXISTS unscored'))
+  }
+}

--- a/db/refresh-materialized.js
+++ b/db/refresh-materialized.js
@@ -1,0 +1,15 @@
+'use strict'
+
+/**
+ * Lambda handler to refresh the "unscored" materialized view.
+ */
+const sequelize = require('../../config/sequelize')
+const rollbar = require('../config/rollbar')
+
+module.exports.handler = rollbar.lambdaHandler((lambdaEvent, lambdaContext, lambdaCallback) => {
+  sequelize.query('REFRESH MATERIALIZED VIEW unscored').then(() => {
+    lambdaCallback(null, 'Successfully refreshed the materialized view: unscored')
+  }).catch((error) => {
+    lambdaCallback('Error refreshing the materialized view: unscored: ' + error)
+  })
+})

--- a/models/unscored.js
+++ b/models/unscored.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const {DataTypes} = require('sequelize')
+const sequelize = require('../config/sequelize')
+
+const Unscored = sequelize().define('Unscored', {
+  uri: {
+    type: DataTypes.STRING(2048),
+    get () {
+      return this.getDataValue('uri').toLowerCase()
+    },
+    primaryKey: true
+  }
+}, {
+  tableName: 'unscored',
+  timestamps: false
+})
+
+module.exports = Unscored

--- a/serverless.yml
+++ b/serverless.yml
@@ -50,6 +50,11 @@ functions:
     timeout: 300
     events:
       - schedule: rate(5 minutes)
+  refresh-materialized:
+    handler: db/refresh-materialized.handler
+    timeout: 300
+    events:
+      - schedule: rate(2 hours)
 
 package:
   exclude:

--- a/serverless.yml
+++ b/serverless.yml
@@ -50,7 +50,7 @@ functions:
     timeout: 300
     events:
       - schedule: rate(5 minutes)
-  refresh-materialized:
+  refresh-unscored:
     handler: db/refresh-materialized.handler
     timeout: 300
     events:

--- a/test/controllers/content.test.js
+++ b/test/controllers/content.test.js
@@ -2,33 +2,25 @@
 
 const ContentController = require('../../api/controllers/content.js')
 const factory = require('../factory')
-const sequelize = require('../../config/sequelize')
+const Unscored = require('../../models/unscored')
 
 describe('ContentController', () => {
-  let event1, event2
+  let unscored1, unscored2
   beforeEach(() => {
     return Promise.all([
-      factory.build('existing_score'),
-      factory.build('blank_score', {
-        uri: 'http://some.other.uri.com',
-        score: 3,
-        weight: 1
-      }),
-      factory.build('web_event', {
-        uri: 'http://some.uri.com'
-      }),
-      factory.build('web_event', {
-        uri: 'http://some.uri.com/1'
-      }),
-      factory.build('web_event', {
+      factory.build('unscored'),
+      factory.build('unscored', {
         uri: 'http://some.other.uri.com'
       }),
-      factory.build('web_event', {
+      factory.build('unscored', {
+        uri: 'http://some.uri.com/1'
+      }),
+      factory.build('unscored', {
         uri: 'http://some.other.uri.com/1'
       })
     ]).then(data => {
-      event1 = data[3]
-      event2 = data[5]
+      unscored1 = data[0]
+      unscored2 = data[1]
     })
   })
 
@@ -48,7 +40,7 @@ describe('ContentController', () => {
         json: (jsonToSet) => {
           expect(jsonToSet).toBeDefined()
           expect(jsonToSet).toEqual({
-            data: [event1.uri],
+            data: [unscored1.uri],
             meta: {
               total: 1
             }
@@ -57,9 +49,8 @@ describe('ContentController', () => {
         }
       }
 
-      jest.spyOn(sequelize(), 'query')
-        .mockImplementationOnce(() => Promise.resolve([{count: 1}]))
-        .mockImplementationOnce(() => Promise.resolve([event1]))
+      jest.spyOn(Unscored, 'findAndCountAll')
+        .mockImplementationOnce(() => Promise.resolve({rows: [unscored1], count: 1}))
 
       ContentController.get(request, response)
     })
@@ -77,7 +68,7 @@ describe('ContentController', () => {
         json: (jsonToSet) => {
           expect(jsonToSet).toBeDefined()
           expect(jsonToSet).toEqual({
-            data: [event1.uri, event2.uri],
+            data: [unscored1.uri, unscored2.uri],
             meta: {
               total: 2
             }
@@ -86,9 +77,8 @@ describe('ContentController', () => {
         }
       }
 
-      jest.spyOn(sequelize(), 'query')
-        .mockImplementationOnce(() => Promise.resolve([{count: 2}]))
-        .mockImplementationOnce(() => Promise.resolve([event1, event2]))
+      jest.spyOn(Unscored, 'findAndCountAll')
+        .mockImplementationOnce(() => Promise.resolve({rows: [unscored1, unscored2], count: 2}))
 
       ContentController.get(request, response)
     })
@@ -115,9 +105,7 @@ describe('ContentController', () => {
         }
       }
 
-      jest.spyOn(sequelize(), 'query')
-        .mockImplementationOnce(() => Promise.resolve([{count: 0}]))
-        .mockImplementationOnce(() => Promise.resolve([]))
+      jest.spyOn(Unscored, 'findAndCountAll').mockImplementationOnce(() => Promise.resolve({rows: [], count: 0}))
 
       ContentController.get(request, response)
     })
@@ -137,15 +125,14 @@ describe('ContentController', () => {
       const response = {
         json: (jsonToSet) => {
           expect(jsonToSet).toBeDefined()
-          expect(jsonToSet.data).toEqual([event1.uri])
+          expect(jsonToSet.data).toEqual([unscored1.uri])
           expect(jsonToSet.meta.total).toEqual(2)
           done()
         }
       }
 
-      jest.spyOn(sequelize(), 'query')
-        .mockImplementationOnce(() => Promise.resolve([{count: 2}]))
-        .mockImplementationOnce(() => Promise.resolve([event1]))
+      jest.spyOn(Unscored, 'findAndCountAll')
+        .mockImplementationOnce(() => Promise.resolve({rows: [unscored1], count: 2}))
 
       ContentController.get(request, response)
     })

--- a/test/factory.js
+++ b/test/factory.js
@@ -4,6 +4,7 @@ const factory = require('factory-girl').factory
 const User = require('../models/user')
 const Event = require('../models/event')
 const Score = require('../models/score')
+const Unscored = require('../models/unscored')
 const ApiUser = require('../models/api-user')
 const chance = require('chance').Chance()
 const path = require('path')
@@ -145,6 +146,10 @@ factory.extend('api_user', 'created_user', {
   api_pattern: ['.*'],
   contact_email: 'frank.test@cru.org',
   type: null
+})
+
+factory.define('unscored', Unscored, {
+  uri: 'http://some.uri.com'
 })
 
 module.exports = factory


### PR DESCRIPTION
This seeks to fix the query timeouts when looking for unscored content by using a materialized view.  Travis build [#482](https://travis-ci.org/CruGlobal/scale-of-belief-lambda/builds/425268235?utm_source=email&utm_medium=notification) seems to have failed migrating to the test database, but I'm not sure where that database lives. 

According to [this](https://www.postgresql.org/docs/9.4/static/sql-creatematerializedview.html) materialized views are supported via a PostgreSQL extension, so maybe that extension is not on the test database that the staging environment is using? The migration worked fine in the staging database itself.