### PR TITLE
Fixes materialized view refresh, which has been failing.

### DIFF
--- a/db/refresh-materialized.js
+++ b/db/refresh-materialized.js
@@ -3,11 +3,11 @@
 /**
  * Lambda handler to refresh the "unscored" materialized view.
  */
-const sequelize = require('../../config/sequelize')
+const sequelize = require('../config/sequelize')
 const rollbar = require('../config/rollbar')
 
 module.exports.handler = rollbar.lambdaHandler((lambdaEvent, lambdaContext, lambdaCallback) => {
-  sequelize.query('REFRESH MATERIALIZED VIEW unscored').then(() => {
+  sequelize().query('REFRESH MATERIALIZED VIEW unscored').then(() => {
     lambdaCallback(null, 'Successfully refreshed the materialized view: unscored')
   }).catch((error) => {
     lambdaCallback('Error refreshing the materialized view: unscored: ' + error)


### PR DESCRIPTION
Refresh has fails on every invocation.
```
Unable to import module 'db/refresh-materialized': Error
at require (internal/module.js:11:18)
```

This fixes the required path and also updates to used computed sequelize object.
