### PR TITLE
KMA-49 - Add a table to track recently scored

### DIFF
--- a/api/controllers/content.js
+++ b/api/controllers/content.js
@@ -4,6 +4,7 @@ const {forEach} = require('lodash')
 const util = require('../util/util')
 const Unscored = require('../../models/unscored')
 const {Op} = require('sequelize')
+const sequelize = require('../../config/sequelize')
 
 const get = (request, response) => {
   let uri = util.sanitizeUri(request.query['uri'])
@@ -22,11 +23,21 @@ const get = (request, response) => {
 
   const offset = (page - 1) * perPage
 
+  const subQuery = sequelize().dialect.QueryGenerator.selectQuery('recently_scored', {attributes: ['uri']})
+    .slice(0, -1) // to remove the ';' from the end of the SQL
+
   Unscored.findAndCountAll({
     where: {
       uri: {
         [Op.like]: uri + '%'
-      }
+      },
+      [Op.and]: [
+        {
+          uri: {
+            [Op.notIn]: sequelize().literal('(' + subQuery + ')')
+          }
+        }
+      ]
     },
     limit: perPage,
     offset: offset,

--- a/api/controllers/score.js
+++ b/api/controllers/score.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Score = require('../../models/score')
+const RecentlyScored = require('../../models/recently-scored')
 const util = require('../util/util')
 const {pick} = require('lodash')
 
@@ -20,7 +21,12 @@ const get = (request, response) => {
 
 const post = (request, response) => {
   var requestBody = request.body
-  Score.save(util.sanitizeUri(requestBody.uri), pick(requestBody, ['score', 'weight'])).then(function (result) {
+  const sanitizedUri = util.sanitizeUri(requestBody.uri)
+
+  Score.save(sanitizedUri, pick(requestBody, ['score', 'weight'])).then(function (result) {
+    // This can be asynchronous
+    RecentlyScored.save(sanitizedUri, requestBody.score)
+
     // On update, we will have a multi-dimensional array (first element being the version), on create we won't
     if (Array.isArray(result)) {
       response.json(Score.toApiScore(result[1][0].dataValues))

--- a/api/controllers/score.js
+++ b/api/controllers/score.js
@@ -23,9 +23,8 @@ const post = (request, response) => {
   var requestBody = request.body
   const sanitizedUri = util.sanitizeUri(requestBody.uri)
 
-  Score.save(sanitizedUri, pick(requestBody, ['score', 'weight'])).then(function (result) {
-    // This can be asynchronous
-    RecentlyScored.save(sanitizedUri, requestBody.score)
+  Score.save(sanitizedUri, pick(requestBody, ['score', 'weight'])).then(async (result) => {
+    await RecentlyScored.save(sanitizedUri, requestBody.score)
 
     // On update, we will have a multi-dimensional array (first element being the version), on create we won't
     if (Array.isArray(result)) {

--- a/config/sequelize.js
+++ b/config/sequelize.js
@@ -11,6 +11,7 @@ const requiredModels = [
   '../models/unscored',
   '../models/api-user',
   '../models/api-key',
+  '../models/recently-scored',
   './papertrail'
 ]
 let database

--- a/db/migrate/20180921075100-create-recently-scored.js
+++ b/db/migrate/20180921075100-create-recently-scored.js
@@ -1,0 +1,19 @@
+'use strict'
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('recently_scored', {
+      uri: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.STRING(2048)
+      },
+      score: {
+        type: Sequelize.INTEGER,
+        defaultValue: 0
+      }
+    })
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('recently_scored')
+  }
+}

--- a/db/migrate/20180921103800-add-last-refreshed-to-unscored.js
+++ b/db/migrate/20180921103800-add-last-refreshed-to-unscored.js
@@ -1,0 +1,34 @@
+'use strict'
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    // First we have to drop the existing materialized view if it exists
+    return queryInterface.removeIndex('unscored', 'idx_unscored_uri')
+      .then(queryInterface.removeIndex('unscored', 'idx_unscored_uri_prefix'))
+      .then(() => queryInterface.sequelize.query('DROP MATERIALIZED VIEW IF EXISTS unscored'))
+
+      // Then we re-create it with the new column
+      .then(() => queryInterface.sequelize.query(
+        'CREATE MATERIALIZED VIEW unscored AS ' +
+        '(SELECT DISTINCT events.uri, now() as last_refreshed ' +
+        'FROM events LEFT JOIN scores USING (uri) ' +
+        'WHERE scores.uri IS NULL) ' +
+        'WITH DATA'))
+
+      // Now we can re-add the indexes
+      .then(() => queryInterface.addIndex('unscored', {fields: ['uri'], unique: true, name: 'idx_unscored_uri'}))
+      .then(() => queryInterface.addIndex('unscored', {fields: ['uri'], operator: 'text_pattern_ops', name: 'idx_unscored_uri_prefix'}))
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeIndex('unscored', 'idx_unscored_uri')
+      .then(queryInterface.removeIndex('unscored', 'idx_unscored_uri_prefix'))
+      .then(() => queryInterface.sequelize.query('DROP MATERIALIZED VIEW IF EXISTS unscored'))
+      .then(() => queryInterface.sequelize.query(
+        'CREATE MATERIALIZED VIEW unscored AS ' +
+        '(SELECT DISTINCT events.uri ' +
+        'FROM events LEFT JOIN scores USING (uri) ' +
+        'WHERE scores.uri IS NULL) ' +
+        'WITH DATA'))
+      .then(() => queryInterface.addIndex('unscored', {fields: ['uri'], unique: true, name: 'idx_unscored_uri'}))
+      .then(() => queryInterface.addIndex('unscored', {fields: ['uri'], operator: 'text_pattern_ops', name: 'idx_unscored_uri_prefix'}))
+  }
+}

--- a/models/recently-scored.js
+++ b/models/recently-scored.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const {DataTypes} = require('sequelize')
+const sequelize = require('../config/sequelize')
+const RecentlyScored = sequelize().define('RecentlyScored', {
+  uri: {
+    type: DataTypes.STRING(2048),
+    get () {
+      return this.getDataValue('uri').toLowerCase()
+    },
+    set (val) {
+      if (val) {
+        this.setDataValue('uri', val.toLowerCase())
+      } else {
+        this.setDataValue('uri', val)
+      }
+    },
+    primaryKey: true
+  },
+  score: {
+    type: DataTypes.INTEGER,
+    validate: {
+      min: 0,
+      max: 10
+    }
+  }
+}, {
+  tableName: 'recently_scored',
+  underscored: true,
+  timestamps: false,
+  getterMethods: {
+    primaryKey () {
+      return this.uri
+    }
+  }
+})
+
+RecentlyScored.retrieve = (uri) => {
+  return RecentlyScored.findOne({
+    where: {
+      uri: uri
+    }
+  })
+}
+
+RecentlyScored.save = (uri, score) => {
+  return sequelize().transaction(function (t) {
+    const upsertData = {
+      uri: uri,
+      score: score
+    }
+
+    return RecentlyScored.findById(uri).then((result) => {
+      if (result) {
+        return result.update(
+          upsertData,
+          {
+            transaction: t,
+            returning: true
+          })
+      } else {
+        return RecentlyScored.create(
+          upsertData,
+          {
+            transaction: t,
+            returning: true
+          })
+      }
+    })
+  })
+}
+
+module.exports = RecentlyScored

--- a/models/recently-scored.test.js
+++ b/models/recently-scored.test.js
@@ -1,0 +1,110 @@
+'use strict'
+
+const RecentlyScored = require('./recently-scored')
+const factory = require('../test/factory')
+
+describe('RecentlyScored', () => {
+  it('should be defined', () => {
+    expect(RecentlyScored).toBeDefined()
+  })
+
+  describe('RecentlyScored.retrieve()', () => {
+    it('should return a recently scored event', done => {
+      factory.build('existing_recent_score').then(existingScore => {
+        expect(existingScore).toBeDefined()
+
+        jest.spyOn(RecentlyScored, 'findOne').mockImplementationOnce(() => {
+          return Promise.resolve(existingScore)
+        })
+
+        RecentlyScored.retrieve(existingScore.uri).then((result) => {
+          expect(result).toBeDefined()
+          expect(result).not.toBeNull()
+          expect(result.dataValues).toEqual(existingScore.dataValues)
+          done()
+        }).catch((err) => {
+          done.fail(err)
+        })
+      }).catch((err) => {
+        done.fail(err)
+      })
+    })
+
+    it('should not return a recently scored event', done => {
+      RecentlyScored.retrieve('http://random.uri.com').then((result) => {
+        expect(result).toBeNull()
+        done()
+      })
+    })
+
+    afterAll(() => {
+      return RecentlyScored.destroy({truncate: true})
+    })
+  })
+
+  describe('RecentlyScored.save()', () => {
+    it('should create a new recently scored event', done => {
+      factory.build('created_recent_score').then((createdScore) => {
+        jest.spyOn(RecentlyScored, 'create').mockImplementationOnce(() => {
+          return createdScore
+        })
+
+        RecentlyScored.save(createdScore.uri, createdScore.score).then((result) => {
+          expect(result).toBeDefined()
+          expect(result.dataValues.uri).toEqual(createdScore.dataValues.uri)
+          expect(result.dataValues.score).toEqual(createdScore.dataValues.score)
+          RecentlyScored.destroy({truncate: true}).then(() => { done() })
+        })
+      })
+    })
+
+    it('should update an existing recently scored event', done => {
+      factory.create('existing_recent_score').then((existingScore) => {
+        factory.build('updated_recent_score').then((updatedScore) => {
+          expect(existingScore).toBeDefined()
+
+          RecentlyScored.save(existingScore.uri, updatedScore.score).then((result) => {
+            expect(result).toBeDefined()
+            expect(result.dataValues.uri).toEqual(existingScore.dataValues.uri)
+
+            expect(result.dataValues.score).toEqual(updatedScore.dataValues.score)
+            expect(result.dataValues.score).not.toEqual(existingScore.dataValues.score)
+            factory.cleanUp().then(() => {
+              RecentlyScored.destroy({truncate: true}).then(() => {
+                done()
+              })
+            })
+          })
+        })
+      })
+    })
+
+    it('should fail if saving with a null URI', done => {
+      // The spyOn calls above are affecting this function, which we don't want
+      jest.resetModules()
+      const unmockedRecentlyScored = require('./recently-scored')
+      unmockedRecentlyScored.save(null, 2).then((result) => {
+        done.fail(new Error('Save should have had an error, instead had result:', result))
+      }).catch((error) => {
+        expect(error).toBeDefined()
+        done()
+      })
+    })
+
+    afterEach(() => {
+      return RecentlyScored.destroy({truncate: true})
+    })
+  })
+
+  describe('RecentlyScored.getPrimaryKey()', () => {
+    let score
+    beforeEach(() => {
+      return factory.build('existing_recent_score').then(existingScore => { score = existingScore })
+    })
+
+    it('should return the uri', () => {
+      const primaryKey = score.get('primaryKey')
+      expect(primaryKey).toEqual(score.uri)
+    })
+  })
+})

--- a/models/unscored.js
+++ b/models/unscored.js
@@ -10,7 +10,8 @@ const Unscored = sequelize().define('Unscored', {
       return this.getDataValue('uri').toLowerCase()
     },
     primaryKey: true
-  }
+  },
+  last_refreshed: DataTypes.DATE
 }, {
   tableName: 'unscored',
   timestamps: false

--- a/scheduled/refresh-materialized.js
+++ b/scheduled/refresh-materialized.js
@@ -6,10 +6,11 @@
 const sequelize = require('../config/sequelize')
 const rollbar = require('../config/rollbar')
 
-module.exports.handler = rollbar.lambdaHandler((lambdaEvent, lambdaContext, lambdaCallback) => {
-  sequelize().query('REFRESH MATERIALIZED VIEW unscored').then(() => {
-    lambdaCallback(null, 'Successfully refreshed the materialized view: unscored')
-  }).catch((error) => {
-    lambdaCallback('Error refreshing the materialized view: unscored: ' + error)
-  })
-})
+module.exports.handler = async (lambdaEvent) => {
+  try {
+    return await sequelize().query('REFRESH MATERIALIZED VIEW unscored')
+  } catch (error) {
+    rollbar.error('Error refreshing the materialized view: unscored: ' + error)
+    throw error
+  }
+}

--- a/scheduled/refresh-materialized.js
+++ b/scheduled/refresh-materialized.js
@@ -5,10 +5,12 @@
  */
 const sequelize = require('../config/sequelize')
 const rollbar = require('../config/rollbar')
+const RecentlyScored = require('../models/recently-scored')
 
 module.exports.handler = async (lambdaEvent) => {
   try {
-    return await sequelize().query('REFRESH MATERIALIZED VIEW unscored')
+    await sequelize().query('REFRESH MATERIALIZED VIEW unscored')
+    return await RecentlyScored.destroy({truncate: true})
   } catch (error) {
     rollbar.error('Error refreshing the materialized view: unscored: ' + error)
     throw error

--- a/scheduled/refresh-materialized.test.js
+++ b/scheduled/refresh-materialized.test.js
@@ -12,10 +12,6 @@ jest.mock('../config/sequelize', () => {
   }
 })
 
-const context = {
-  getRemainingTimeInMillis: jest.fn()
-}
-
 describe('Refresh Materialized lambda', () => {
   it('Should be defined', () => {
     expect(lambda).toBeDefined()
@@ -25,11 +21,10 @@ describe('Refresh Materialized lambda', () => {
     jest.clearAllMocks()
     mockQuery.mockImplementation(() => Promise.resolve())
 
-    lambda.handler(null, context, (error, message) => {
-      expect(error).toBeNull()
-      expect(message).toBeDefined()
-      expect(message).toEqual('Successfully refreshed the materialized view: unscored')
+    lambda.handler(null).then(() => {
       done()
+    }).catch((error) => {
+      done.fail(error)
     })
   })
 
@@ -39,9 +34,11 @@ describe('Refresh Materialized lambda', () => {
     mockQuery.mockImplementation(() => Promise.reject(new Error('No materialized view exists with the name "unscored"'))
     )
 
-    lambda.handler(null, context, (error, message) => {
+    lambda.handler(null).then((message) => {
+      done.fail()
+    }).catch((error) => {
       expect(error).not.toBeNull()
-      expect(error).toEqual('Error refreshing the materialized view: unscored: Error: No materialized view exists with the name "unscored"')
+      expect(error).toEqual(new Error('No materialized view exists with the name "unscored"'))
       done()
     })
   })

--- a/scheduled/refresh-materialized.test.js
+++ b/scheduled/refresh-materialized.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const lambda = require('./refresh-materialized')
+const RecentlyScored = require('../models/recently-scored')
 
 const mockQuery = jest.fn()
 
@@ -17,8 +18,11 @@ describe('Refresh Materialized lambda', () => {
     expect(lambda).toBeDefined()
   })
 
+  const mockTruncate = jest.fn()
+
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.spyOn(RecentlyScored, 'destroy').mockImplementation(mockTruncate)
   })
 
   it('Should successfully refresh the materialized view', done => {
@@ -42,6 +46,17 @@ describe('Refresh Materialized lambda', () => {
       expect(error).not.toBeNull()
       expect(error).toEqual(new Error('No materialized view exists with the name "unscored"'))
       done()
+    })
+  })
+
+  it('Should truncate the recently_scored table', done => {
+    mockQuery.mockImplementation(() => Promise.resolve())
+
+    lambda.handler(null).then(() => {
+      expect(mockTruncate).toHaveBeenCalled()
+      done()
+    }).catch((error) => {
+      done.fail(error)
     })
   })
 })

--- a/scheduled/refresh-materialized.test.js
+++ b/scheduled/refresh-materialized.test.js
@@ -17,8 +17,11 @@ describe('Refresh Materialized lambda', () => {
     expect(lambda).toBeDefined()
   })
 
-  it('Should successfully refresh the materialized view', done => {
+  beforeEach(() => {
     jest.clearAllMocks()
+  })
+
+  it('Should successfully refresh the materialized view', done => {
     mockQuery.mockImplementation(() => Promise.resolve())
 
     lambda.handler(null).then(() => {
@@ -29,10 +32,9 @@ describe('Refresh Materialized lambda', () => {
   })
 
   it('Should fail to refresh the materialized view', done => {
-    jest.clearAllMocks()
-    mockQuery.mockClear()
-    mockQuery.mockImplementation(() => Promise.reject(new Error('No materialized view exists with the name "unscored"'))
-    )
+    mockQuery.mockImplementation(() => {
+      return Promise.reject(new Error('No materialized view exists with the name "unscored"'))
+    })
 
     lambda.handler(null).then((message) => {
       done.fail()

--- a/test/controllers/content.test.js
+++ b/test/controllers/content.test.js
@@ -3,6 +3,9 @@
 const ContentController = require('../../api/controllers/content.js')
 const factory = require('../factory')
 const Unscored = require('../../models/unscored')
+const RecentlyScored = require('../../models/recently-scored')
+const Event = require('../../models/event')
+const sequelize = require('../../config/sequelize')
 
 describe('ContentController', () => {
   let unscored1, unscored2
@@ -135,6 +138,58 @@ describe('ContentController', () => {
         .mockImplementationOnce(() => Promise.resolve({rows: [unscored1], count: 2}))
 
       ContentController.get(request, response)
+    })
+  })
+
+  describe('checks recently_scored', () => {
+    const setupDb = async () => {
+      await RecentlyScored.destroy({truncate: true})
+      await factory.cleanUp()
+
+      // Try/catch on these because sometimes the db is out of sync and we get a unique constraint error
+      try {
+        await factory.create('existing_recent_score')
+      } catch (err) {}
+
+      try {
+        await factory.create('web_event', { uri: 'http://some.other.uri.com' })
+      } catch (err) {}
+
+      return sequelize().query('REFRESH MATERIALIZED VIEW unscored')
+    }
+
+    it('should not returned a recently scored event as unscored', async (done) => {
+      await setupDb()
+
+      const request = {
+        query: {
+          uri: 'http',
+          page: '1',
+          per_page: '1',
+          order: 'ASC'
+        }
+      }
+
+      const response = {
+        json: (jsonToSet) => {
+          try {
+            expect(jsonToSet).toBeDefined()
+            expect(jsonToSet.data).toEqual([unscored2.uri])
+            expect(jsonToSet.meta.total).toEqual(1)
+            done()
+          } catch (err) {
+            done.fail(err)
+          }
+        }
+      }
+
+      ContentController.get(request, response)
+    })
+
+    afterEach(async () => {
+      return RecentlyScored.destroy({truncate: true})
+        .then(() => { Event.destroy({truncate: true}) })
+        .then(() => { sequelize().query('REFRESH MATERIALIZED VIEW unscored') })
     })
   })
 })

--- a/test/factory.js
+++ b/test/factory.js
@@ -6,6 +6,7 @@ const Event = require('../models/event')
 const Score = require('../models/score')
 const Unscored = require('../models/unscored')
 const ApiUser = require('../models/api-user')
+const RecentlyScored = require('../models/recently-scored')
 const chance = require('chance').Chance()
 const path = require('path')
 const fs = require('fs')
@@ -150,6 +151,22 @@ factory.extend('api_user', 'created_user', {
 
 factory.define('unscored', Unscored, {
   uri: 'http://some.uri.com'
+})
+
+factory.define('blank_recent_score', RecentlyScored, {})
+
+factory.extend('blank_recent_score', 'existing_recent_score', {
+  uri: 'http://some.uri.com',
+  score: 5
+})
+
+factory.extend('blank_recent_score', 'created_recent_score', {
+  uri: 'http://somewhere.com/1',
+  score: 1
+})
+
+factory.extend('existing_recent_score', 'updated_recent_score', {
+  score: 2
 })
 
 module.exports = factory

--- a/test/factory.js
+++ b/test/factory.js
@@ -150,7 +150,8 @@ factory.extend('api_user', 'created_user', {
 })
 
 factory.define('unscored', Unscored, {
-  uri: 'http://some.uri.com'
+  uri: 'http://some.uri.com',
+  last_refreshed: new Date()
 })
 
 factory.define('blank_recent_score', RecentlyScored, {})


### PR DESCRIPTION
This PR will add a new table `recently_scored` to hold data temporarily to bridge the gap between refreshes of the `unscored` materialized view. Basically, a user will score an event, then it will go into the `recently_scored` table. The query for unscored will look at the materialized view, then at the new table to ensure they don't show up in the list of unscored. 

When the materialized view is refreshed, the `recently_scored` table is truncated.