### PR TITLE
KMA-51 - sync scores to AEM

### DIFF
--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -34,14 +34,9 @@ AWS.S3.prototype = {
 }
 
 AWS.SNS = function () {}
-
-AWS.SNS.prototype = {
-  ...AWS.SNS.prototype,
-
-  publish (params, callback) {
-    callback(null, 1)
-  }
-}
+AWS.SNS.prototype.publish = jest.fn().mockImplementation((params, callback) => {
+  callback(null, 1)
+})
 
 // Export my AWS function so it can be referenced via requires
 module.exports = AWS

--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -33,5 +33,15 @@ AWS.S3.prototype = {
   }
 }
 
+AWS.SNS = function () {}
+
+AWS.SNS.prototype = {
+  ...AWS.SNS.prototype,
+
+  publish (params, callback) {
+    callback(null, 1)
+  }
+}
+
 // Export my AWS function so it can be referenced via requires
 module.exports = AWS

--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -35,7 +35,11 @@ AWS.S3.prototype = {
 
 AWS.SNS = function () {}
 AWS.SNS.prototype.publish = jest.fn().mockImplementation((params, callback) => {
-  callback(null, 1)
+  if (params.Message.indexOf('http://fail.com/') !== -1) {
+    callback(new Error('Failed to send SNS message'))
+  } else {
+    callback(null, 1)
+  }
 })
 
 // Export my AWS function so it can be referenced via requires

--- a/api/controllers/score.js
+++ b/api/controllers/score.js
@@ -4,6 +4,7 @@ const Score = require('../../models/score')
 const RecentlyScored = require('../../models/recently-scored')
 const util = require('../util/util')
 const {pick} = require('lodash')
+const AWS = require('aws-sdk')
 
 const get = (request, response) => {
   var uri = util.sanitizeUri(request.query['uri'])
@@ -25,6 +26,7 @@ const post = (request, response) => {
 
   Score.save(sanitizedUri, pick(requestBody, ['score', 'weight'])).then(async (result) => {
     await RecentlyScored.save(sanitizedUri, requestBody.score)
+    await sendSns(sanitizedUri, requestBody.score)
 
     // On update, we will have a multi-dimensional array (first element being the version), on create we won't
     if (Array.isArray(result)) {
@@ -32,6 +34,27 @@ const post = (request, response) => {
     } else {
       response.json(Score.toApiScore(result.dataValues))
     }
+  })
+}
+
+const sendSns = async (sanitizedUri, score) => {
+  const sns = new AWS.SNS({ region: 'us-east-1' })
+  const payload = {
+    uri: sanitizedUri,
+    score: score
+  }
+  const params = {
+    Message: JSON.stringify(payload),
+    TopicArn: process.env.AEM_SNS_TOPIC_ARN
+  }
+
+  return new Promise((resolve, reject) => {
+    sns.publish(params, (error, data) => {
+      if (error) {
+        reject(error)
+      }
+      resolve(data)
+    })
   })
 }
 

--- a/api/controllers/score.js
+++ b/api/controllers/score.js
@@ -5,6 +5,7 @@ const RecentlyScored = require('../../models/recently-scored')
 const util = require('../util/util')
 const {pick} = require('lodash')
 const AWS = require('aws-sdk')
+const rollbar = require('../../config/rollbar')
 
 const get = (request, response) => {
   var uri = util.sanitizeUri(request.query['uri'])
@@ -26,7 +27,13 @@ const post = (request, response) => {
 
   Score.save(sanitizedUri, pick(requestBody, ['score', 'weight'])).then(async (result) => {
     await RecentlyScored.save(sanitizedUri, requestBody.score)
-    await sendSns(sanitizedUri, requestBody.score)
+
+    try {
+      await sendSns(sanitizedUri, requestBody.score)
+    } catch (err) {
+      // We don't want to fail the request if this fails, but we should probably log it
+      rollbar.warn(err)
+    }
 
     // On update, we will have a multi-dimensional array (first element being the version), on create we won't
     if (Array.isArray(result)) {

--- a/config/aem.js
+++ b/config/aem.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const AemClient = require('../models/aem-client')
+
+module.exports = new AemClient(process.env['AEM_URL'], process.env['AEM_USERNAME'], process.env['AEM_PASSWORD'])

--- a/models/aem-client.js
+++ b/models/aem-client.js
@@ -20,7 +20,7 @@ class AemClient {
     const auth = 'Basic ' + Buffer.from(this.username + ':' + this.password).toString('base64')
 
     let options = {
-      url: `${this.baseUrl}/${path}/_jcr_content`,
+      url: `${this.baseUrl}${path}/_jcr_content`,
       form: this.scoreBody(score),
       headers: {
         'authorization': auth

--- a/models/aem-client.js
+++ b/models/aem-client.js
@@ -16,7 +16,7 @@ class AemClient {
    * @param score an integer value representing the score
    */
   updateScore (uri, score) {
-    const path = uri.pathname
+    const path = uri.pathname.replace('.html', '')
     const auth = 'Basic ' + Buffer.from(this.username + ':' + this.password).toString('base64')
 
     let options = {
@@ -45,7 +45,7 @@ class AemClient {
   }
 
   publish (uri) {
-    const path = uri.pathname
+    const path = uri.pathname.replace('.html', '')
     const auth = 'Basic ' + Buffer.from(this.username + ':' + this.password).toString('base64')
 
     let options = {

--- a/models/aem-client.js
+++ b/models/aem-client.js
@@ -43,6 +43,35 @@ class AemClient {
       './contentScoreLastUpdated': new Date()
     }
   }
+
+  publish (uri) {
+    const path = uri.pathname
+    const auth = 'Basic ' + Buffer.from(this.username + ':' + this.password).toString('base64')
+
+    let options = {
+      url: `${this.baseUrl}/bin/replicate.json`,
+      form: this.publishBody(path),
+      headers: {
+        'authorization': auth
+      }
+    }
+    return new Promise((resolve, reject) => {
+      request.post(options, (err, response, body) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(response)
+        }
+      })
+    })
+  }
+
+  publishBody (path) {
+    return {
+      path: path,
+      cmd: 'activate'
+    }
+  }
 }
 
 module.exports = AemClient

--- a/models/aem-client.js
+++ b/models/aem-client.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const request = require('request')
+
+class AemClient {
+  constructor (baseUrl, username, password) {
+    this.baseUrl = baseUrl
+    this.username = username
+    this.password = password
+  }
+
+  /**
+   * Updates the given page in AEM with the given score.
+   *
+   * @param uri a Url object of the page to update
+   * @param score an integer value representing the score
+   */
+  updateScore (uri, score) {
+    const path = uri.pathname
+    const auth = 'Basic ' + Buffer.from(this.username + ':' + this.password).toString('base64')
+
+    let options = {
+      url: `${this.baseUrl}/${path}/_jcr_content`,
+      form: this.scoreBody(score),
+      headers: {
+        'authorization': auth
+      }
+    }
+    return new Promise((resolve, reject) => {
+      request.post(options, (err, response, body) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(response)
+        }
+      })
+    })
+  }
+
+  scoreBody (score) {
+    return {
+      './score': score,
+      './contentScoreLastUpdated': new Date()
+    }
+  }
+}
+
+module.exports = AemClient

--- a/models/aem-client.js
+++ b/models/aem-client.js
@@ -16,12 +16,11 @@ class AemClient {
    * @param score an integer value representing the score
    */
   updateScore (uri, score) {
-    const path = uri.pathname.replace('.html', '')
     const auth = 'Basic ' + Buffer.from(this.username + ':' + this.password).toString('base64')
 
     let options = {
-      url: `${this.baseUrl}${path}/_jcr_content`,
-      form: this.scoreBody(score),
+      url: `${this.baseUrl}/bin/content-scoring/sync`,
+      form: this.scoreBody(score, uri),
       headers: {
         'authorization': auth
       }
@@ -37,39 +36,10 @@ class AemClient {
     })
   }
 
-  scoreBody (score) {
+  scoreBody (score, uri) {
     return {
-      './score': score,
-      './contentScoreLastUpdated': new Date()
-    }
-  }
-
-  publish (uri) {
-    const path = uri.pathname.replace('.html', '')
-    const auth = 'Basic ' + Buffer.from(this.username + ':' + this.password).toString('base64')
-
-    let options = {
-      url: `${this.baseUrl}/bin/replicate.json`,
-      form: this.publishBody(path),
-      headers: {
-        'authorization': auth
-      }
-    }
-    return new Promise((resolve, reject) => {
-      request.post(options, (err, response, body) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve(response)
-        }
-      })
-    })
-  }
-
-  publishBody (path) {
-    return {
-      path: path,
-      cmd: 'activate'
+      score: score,
+      resourceUri: uri
     }
   }
 }

--- a/models/aem-client.test.js
+++ b/models/aem-client.test.js
@@ -33,16 +33,11 @@ describe('AemClient', () => {
         callback(null, {}, {})
       })
 
-      const currentDate = new Date()
-
-      const RealDate = Date
-      global.Date = jest.fn(() => new RealDate(currentDate.toISOString()))
-
       const options = {
-        url: 'http://localhost:4502/content/siteName/path/pageName/_jcr_content',
+        url: 'http://localhost:4502/bin/content-scoring/sync',
         form: {
-          './score': 5,
-          './contentScoreLastUpdated': new Date()
+          score: 5,
+          resourceUri: url.parse(resourceUrl)
         },
         headers: {
           'authorization': auth
@@ -51,10 +46,8 @@ describe('AemClient', () => {
 
       client.updateScore(resourceUrl, 5).then(() => {
         expect(requestMock).toHaveBeenCalledWith(options, expect.any(Function))
-        Object.assign(Date, RealDate)
         done()
       }).catch((err) => {
-        Object.assign(Date, RealDate)
         done.fail(err)
       })
     })
@@ -66,48 +59,7 @@ describe('AemClient', () => {
 
       client.updateScore(resourceUrl, 5).then(() => {
         done.fail(new Error('It should have failed'))
-      }).catch((err) => {
-        expect(requestMock).toHaveBeenCalled()
-        done()
-      })
-    })
-  })
-
-  describe('publish', () => {
-    const client = new AemClient(aemUrl, username, password)
-    const resourceUrl = url.parse('http://some-site.org/content/siteName/path/pageName.html')
-
-    it('Should successfully publish the changes', done => {
-      const options = {
-        url: 'http://localhost:4502/bin/replicate.json',
-        form: {
-          path: '/content/siteName/path/pageName',
-          cmd: 'activate'
-        },
-        headers: {
-          'authorization': auth
-        }
-      }
-      const requestMock = jest.spyOn(request, 'post').mockImplementationOnce((options, callback) => {
-        callback(null, {}, {})
-      })
-
-      client.publish(resourceUrl).then(() => {
-        expect(requestMock).toHaveBeenCalledWith(options, expect.any(Function))
-        done()
-      }).catch((err) => {
-        done.fail(err)
-      })
-    })
-
-    it('Should fail to publish the changes', done => {
-      const requestMock = jest.spyOn(request, 'post').mockImplementationOnce((options, callback) => {
-        callback(new Error('Failed to publish'), {}, {})
-      })
-
-      client.publish(resourceUrl).then(() => {
-        done.fail(new Error('It should have failed'))
-      }).catch((err) => {
+      }).catch(() => {
         expect(requestMock).toHaveBeenCalled()
         done()
       })

--- a/models/aem-client.test.js
+++ b/models/aem-client.test.js
@@ -1,0 +1,116 @@
+'use strict'
+
+const AemClient = require('./aem-client')
+const request = require('request')
+const url = require('url')
+
+describe('AemClient', () => {
+  it('Should be defined', () => {
+    expect(AemClient).toBeDefined()
+  })
+
+  const aemUrl = 'http://localhost:4502'
+  const username = 'username'
+  const password = 'password'
+  const auth = 'Basic ' + Buffer.from(username + ':' + password).toString('base64')
+
+  describe('constructor', () => {
+    it('Should set url, username, and password', () => {
+      const client = new AemClient(aemUrl, username, password)
+
+      expect(client.baseUrl).toEqual(aemUrl)
+      expect(client.username).toEqual(username)
+      expect(client.password).toEqual(password)
+    })
+  })
+
+  describe('updateScore', () => {
+    const client = new AemClient(aemUrl, username, password)
+    const resourceUrl = url.parse('http://some-site.org/content/siteName/path/pageName.html')
+
+    it('Should successfully update the score in AEM', done => {
+      const requestMock = jest.spyOn(request, 'post').mockImplementationOnce((options, callback) => {
+        callback(null, {}, {})
+      })
+
+      const currentDate = new Date()
+
+      const RealDate = Date
+      global.Date = jest.fn(() => new RealDate(currentDate.toISOString()))
+
+      const options = {
+        url: 'http://localhost:4502/content/siteName/path/pageName/_jcr_content',
+        form: {
+          './score': 5,
+          './contentScoreLastUpdated': new Date()
+        },
+        headers: {
+          'authorization': auth
+        }
+      }
+
+      client.updateScore(resourceUrl, 5).then(() => {
+        expect(requestMock).toHaveBeenCalledWith(options, expect.any(Function))
+        Object.assign(Date, RealDate)
+        done()
+      }).catch((err) => {
+        Object.assign(Date, RealDate)
+        done.fail(err)
+      })
+    })
+
+    it('Should fail to update the score in AEM', done => {
+      const requestMock = jest.spyOn(request, 'post').mockImplementationOnce((options, callback) => {
+        callback(new Error('Failed to send'), {}, {})
+      })
+
+      client.updateScore(resourceUrl, 5).then(() => {
+        done.fail(new Error('It should have failed'))
+      }).catch((err) => {
+        expect(requestMock).toHaveBeenCalled()
+        done()
+      })
+    })
+  })
+
+  describe('publish', () => {
+    const client = new AemClient(aemUrl, username, password)
+    const resourceUrl = url.parse('http://some-site.org/content/siteName/path/pageName.html')
+
+    it('Should successfully publish the changes', done => {
+      const options = {
+        url: 'http://localhost:4502/bin/replicate.json',
+        form: {
+          path: '/content/siteName/path/pageName',
+          cmd: 'activate'
+        },
+        headers: {
+          'authorization': auth
+        }
+      }
+      const requestMock = jest.spyOn(request, 'post').mockImplementationOnce((options, callback) => {
+        callback(null, {}, {})
+      })
+
+      client.publish(resourceUrl).then(() => {
+        expect(requestMock).toHaveBeenCalledWith(options, expect.any(Function))
+        done()
+      }).catch((err) => {
+        done.fail(err)
+      })
+    })
+
+    it('Should fail to publish the changes', done => {
+      const requestMock = jest.spyOn(request, 'post').mockImplementationOnce((options, callback) => {
+        callback(new Error('Failed to publish'), {}, {})
+      })
+
+      client.publish(resourceUrl).then(() => {
+        done.fail(new Error('It should have failed'))
+      }).catch((err) => {
+        expect(requestMock).toHaveBeenCalled()
+        done()
+      })
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -995,10 +995,24 @@
         "xml2js": "0.4.19"
       },
       "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
         "sax": {
           "version": "1.2.1",
-          "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
           "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
         }
       }
     },
@@ -1157,7 +1171,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
@@ -1477,7 +1491,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
         "base64-js": "^1.0.2",
@@ -2108,7 +2122,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -3461,7 +3475,7 @@
     },
     "external-editor": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
       "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
       "dev": true,
       "requires": {
@@ -4425,7 +4439,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -4504,7 +4518,7 @@
         },
         "joi": {
           "version": "9.2.0",
-          "resolved": "http://registry.npmjs.org/joi/-/joi-9.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-9.2.0.tgz",
           "integrity": "sha1-M4WseQGSEwy+Iw6ALsAskhW7/to=",
           "dev": true,
           "requires": {
@@ -4590,7 +4604,7 @@
         },
         "joi": {
           "version": "9.2.0",
-          "resolved": "http://registry.npmjs.org/joi/-/joi-9.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-9.2.0.tgz",
           "integrity": "sha1-M4WseQGSEwy+Iw6ALsAskhW7/to=",
           "dev": true,
           "requires": {
@@ -4954,7 +4968,7 @@
     },
     "inquirer": {
       "version": "1.2.3",
-      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
       "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
       "dev": true,
       "requires": {
@@ -4988,7 +5002,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -5298,7 +5312,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -5752,7 +5766,7 @@
     },
     "jest-get-type": {
       "version": "22.4.3",
-      "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
       "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
       "dev": true
     },
@@ -6354,7 +6368,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -7948,7 +7962,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -8733,7 +8747,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -8755,7 +8769,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
@@ -9090,7 +9104,7 @@
         },
         "jsonfile": {
           "version": "2.4.0",
-          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
@@ -9099,7 +9113,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -9621,7 +9635,7 @@
         },
         "joi": {
           "version": "9.2.0",
-          "resolved": "http://registry.npmjs.org/joi/-/joi-9.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-9.2.0.tgz",
           "integrity": "sha1-M4WseQGSEwy+Iw6ALsAskhW7/to=",
           "dev": true,
           "requires": {
@@ -9965,7 +9979,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -10303,7 +10317,7 @@
         },
         "buffer": {
           "version": "3.6.0",
-          "resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
           "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
           "dev": true,
           "requires": {
@@ -10474,9 +10488,9 @@
       "dev": true
     },
     "url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -10631,7 +10645,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -10782,7 +10796,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "serverless-http": "^1.6.0",
     "swaggerize-express": "^4.0.5",
     "umzug": "^2.1.0",
+    "url": "^0.11.0",
     "winston": "^2.4.4",
     "xml2js": "^0.4.19"
   },

--- a/serverless.yml
+++ b/serverless.yml
@@ -62,6 +62,11 @@ functions:
     timeout: 300
     events:
       - schedule: rate(4 hours)
+  sync-score:
+    handler: sns/sync-score.handler
+    timeout: 30
+    events:
+      - sns: ${env:AEM_SNS_TOPIC_ARN}
 
 package:
   exclude:

--- a/serverless/environment.js
+++ b/serverless/environment.js
@@ -30,6 +30,10 @@ module.exports = () => {
     ACS_API_KEY: process.env['ACS_API_KEY'] || '',
     ACS_URL: process.env['ACS_URL'] || 'https://mc.adobe.io/cru/campaign/',
     SNS_TOPIC_ARN: process.env['SNS_TOPIC_ARN'] || '',
-    KINESIS_SNOWPLOW_ENRICH_ARN: process.env['KINESIS_SNOWPLOW_ENRICH_ARN'] || ''
+    KINESIS_SNOWPLOW_ENRICH_ARN: process.env['KINESIS_SNOWPLOW_ENRICH_ARN'] || '',
+    AEM_URL: process.env['AEM_URL'] || 'http://localhost:4502',
+    AEM_USERNAME: process.env['AEM_USERNAME'] || '',
+    AEM_PASSWORD: process.env['AEM_PASSWORD'] || '',
+    AEM_SNS_TOPIC_ARN: process.env['AEM_SNS_TOPIC_ARN'] || ''
   }
 }

--- a/sns/sync-score.js
+++ b/sns/sync-score.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const rollbar = require('../config/rollbar')
+const AemClient = require('../config/aem')
+const url = require('url')
+
+module.exports.handler = async (lambdaEvent) => {
+  try {
+    // Decode SNS message
+    const snsMessage = lambdaEvent.Records[0].Sns.Message
+    const message = JSON.parse(snsMessage)
+
+    // Update score in AEM
+    await AemClient.updateScore(url.parse(message.uri), message.score)
+  } catch (err) {
+    rollbar.error('Error syncing score update to AEM' + err)
+    throw err
+  }
+}

--- a/sns/sync-score.js
+++ b/sns/sync-score.js
@@ -11,7 +11,9 @@ module.exports.handler = async (lambdaEvent) => {
     const message = JSON.parse(snsMessage)
 
     // Update score in AEM
-    await AemClient.updateScore(url.parse(message.uri), message.score)
+    const resourceUrl = url.parse(message.uri)
+    await AemClient.updateScore(resourceUrl, message.score)
+    await AemClient.publish(resourceUrl)
   } catch (err) {
     rollbar.error('Error syncing score update to AEM' + err)
     throw err

--- a/sns/sync-score.js
+++ b/sns/sync-score.js
@@ -11,9 +11,7 @@ module.exports.handler = async (lambdaEvent) => {
     const message = JSON.parse(snsMessage)
 
     // Update score in AEM
-    const resourceUrl = url.parse(message.uri)
-    await AemClient.updateScore(resourceUrl, message.score)
-    await AemClient.publish(resourceUrl)
+    await AemClient.updateScore(url.parse(message.uri), message.score)
   } catch (err) {
     rollbar.error('Error syncing score update to AEM' + err)
     throw err

--- a/sns/sync-score.test.js
+++ b/sns/sync-score.test.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const AemClient = require('../config/aem')
+const SyncScore = require('./sync-score')
+const url = require('url')
+
+describe('Sync-Score SNS Lambda', () => {
+  it('Should be defined', () => {
+    expect(SyncScore).toBeDefined()
+  })
+
+  const payload = {
+    uri: 'http://localhost:4502/content/siteName/us/en/pageName.html',
+    score: 5
+  }
+  const snsMessage = {
+    Records: [
+      {
+        Sns: {
+          Message: JSON.stringify(payload)
+        }
+      }
+    ]
+  }
+
+  it('Should send the score to AEM author', done => {
+    jest.spyOn(AemClient, 'updateScore').mockResolvedValue()
+    jest.spyOn(AemClient, 'publish').mockResolvedValue()
+
+    SyncScore.handler(snsMessage).then(() => {
+      expect(AemClient.updateScore).toHaveBeenCalledWith(url.parse(payload.uri), payload.score)
+      done()
+    }).catch((err) => {
+      done.fail(err)
+    })
+  })
+
+  it('Should publish the changes', done => {
+    jest.spyOn(AemClient, 'updateScore').mockResolvedValue()
+    jest.spyOn(AemClient, 'publish').mockResolvedValue()
+
+    SyncScore.handler(snsMessage).then(() => {
+      expect(AemClient.publish).toHaveBeenCalledWith(url.parse(payload.uri))
+      done()
+    }).catch((err) => {
+      done.fail(err)
+    })
+  })
+
+  it('Should fail to send the score to AEM author', done => {
+    jest.spyOn(AemClient, 'updateScore').mockRejectedValue(new Error('Failed to send'))
+    jest.spyOn(AemClient, 'publish').mockResolvedValue()
+
+    SyncScore.handler(snsMessage).then(() => {
+      done.fail(new Error('It should have failed'))
+    }).catch((err) => {
+      expect(err).toEqual(new Error('Failed to send'))
+      done()
+    })
+  })
+
+  it('Should fail to publish the changes', done => {
+    jest.spyOn(AemClient, 'updateScore').mockResolvedValue()
+    jest.spyOn(AemClient, 'publish').mockRejectedValue(new Error('Failed to publish'))
+
+    SyncScore.handler(snsMessage).then(() => {
+      done.fail(new Error('It should have failed'))
+    }).catch((err) => {
+      expect(err).toEqual(new Error('Failed to publish'))
+      done()
+    })
+  })
+})

--- a/sns/sync-score.test.js
+++ b/sns/sync-score.test.js
@@ -25,7 +25,6 @@ describe('Sync-Score SNS Lambda', () => {
 
   it('Should send the score to AEM author', done => {
     jest.spyOn(AemClient, 'updateScore').mockResolvedValue()
-    jest.spyOn(AemClient, 'publish').mockResolvedValue()
 
     SyncScore.handler(snsMessage).then(() => {
       expect(AemClient.updateScore).toHaveBeenCalledWith(url.parse(payload.uri), payload.score)
@@ -35,38 +34,13 @@ describe('Sync-Score SNS Lambda', () => {
     })
   })
 
-  it('Should publish the changes', done => {
-    jest.spyOn(AemClient, 'updateScore').mockResolvedValue()
-    jest.spyOn(AemClient, 'publish').mockResolvedValue()
-
-    SyncScore.handler(snsMessage).then(() => {
-      expect(AemClient.publish).toHaveBeenCalledWith(url.parse(payload.uri))
-      done()
-    }).catch((err) => {
-      done.fail(err)
-    })
-  })
-
   it('Should fail to send the score to AEM author', done => {
     jest.spyOn(AemClient, 'updateScore').mockRejectedValue(new Error('Failed to send'))
-    jest.spyOn(AemClient, 'publish').mockResolvedValue()
 
     SyncScore.handler(snsMessage).then(() => {
       done.fail(new Error('It should have failed'))
     }).catch((err) => {
       expect(err).toEqual(new Error('Failed to send'))
-      done()
-    })
-  })
-
-  it('Should fail to publish the changes', done => {
-    jest.spyOn(AemClient, 'updateScore').mockResolvedValue()
-    jest.spyOn(AemClient, 'publish').mockRejectedValue(new Error('Failed to publish'))
-
-    SyncScore.handler(snsMessage).then(() => {
-      done.fail(new Error('It should have failed'))
-    }).catch((err) => {
-      expect(err).toEqual(new Error('Failed to publish'))
       done()
     })
   })

--- a/test/controllers/score.test.js
+++ b/test/controllers/score.test.js
@@ -4,6 +4,7 @@ const ScoreController = require('../../api/controllers/score.js')
 const factory = require('../factory')
 const Score = require('../../models/score')
 const RecentlyScored = require('../../models/recently-scored')
+const AWS = require('aws-sdk')
 
 describe('ScoreController', () => {
   let score
@@ -190,6 +191,37 @@ describe('ScoreController', () => {
       const response = {
         json: (jsonToSet) => {
           expect(RecentlyScored.save).toHaveBeenCalledWith(newUri, newScore.score)
+          done()
+        }
+      }
+
+      jest.spyOn(Score, 'save').mockImplementation(() => Promise.resolve(createdScore))
+
+      ScoreController.post(request, response)
+    })
+
+    test('should send SNS message to sync score to AEM', done => {
+      const newUri = 'http://somewhere.com/1'
+      const newScore = {
+        score: 1,
+        weight: 6
+      }
+      const request = {
+        body: Object.assign({uri: newUri}, newScore)
+      }
+
+      const payload = {
+        uri: newUri,
+        score: newScore.score
+      }
+      const params = {
+        Message: JSON.stringify(payload),
+        TopicArn: process.env.AEM_SNS_TOPIC_ARN
+      }
+
+      const response = {
+        json: (jsonToSet) => {
+          expect(AWS.SNS.prototype.publish).toHaveBeenCalledWith(params, expect.any(Function))
           done()
         }
       }

--- a/test/controllers/score.test.js
+++ b/test/controllers/score.test.js
@@ -5,6 +5,13 @@ const factory = require('../factory')
 const Score = require('../../models/score')
 const RecentlyScored = require('../../models/recently-scored')
 const AWS = require('aws-sdk')
+const rollbar = require('../../config/rollbar')
+
+jest.mock('../../config/rollbar', () => {
+  return {
+    warn: jest.fn()
+  }
+})
 
 describe('ScoreController', () => {
   let score
@@ -222,6 +229,28 @@ describe('ScoreController', () => {
       const response = {
         json: (jsonToSet) => {
           expect(AWS.SNS.prototype.publish).toHaveBeenCalledWith(params, expect.any(Function))
+          done()
+        }
+      }
+
+      jest.spyOn(Score, 'save').mockImplementation(() => Promise.resolve(createdScore))
+
+      ScoreController.post(request, response)
+    })
+
+    test('should continue if the SNS message fails to send', done => {
+      const newUri = 'http://fail.com/'
+      const newScore = {
+        score: 1,
+        weight: 6
+      }
+      const request = {
+        body: Object.assign({uri: newUri}, newScore)
+      }
+
+      const response = {
+        json: (jsonToSet) => {
+          expect(rollbar.warn).toHaveBeenCalledWith(new Error('Failed to send SNS message'))
           done()
         }
       }


### PR DESCRIPTION
This PR will send an SNS message upon updating scores via [scale-of-belief-web](https://github.com/CruGlobal/scale-of-belief-web). The SNS message will call a servlet set up in AEM (see https://github.com/CruGlobal/cru-aem-content-scoring/pull/4). The servlet will find the correct node given the URL (or none if it's not an AEM URL) and save the score to the JCR (specifically the `jcr:content` node of the page found).

This PR depends on 
https://github.com/CruGlobal/ecs_config/pull/339
https://github.com/CruGlobal/cru-aem-content-scoring/pull/4
User `scale-of-belief` being created inside of AEM author