### PR TITLE
Remove LIMIT 1 from User query.

### DIFF
--- a/api/controllers/placement.js
+++ b/api/controllers/placement.js
@@ -3,7 +3,7 @@
 const User = require('../../models/user')
 const Placement = require('../../models/placement')
 const {Op} = require('sequelize')
-const {identity, isEmpty, isNull, mapValues, pickBy} = require('lodash')
+const {identity, isEmpty, mapValues, pickBy} = require('lodash')
 
 const get = (request, response) => {
   let params = mapValues(pickBy(request.query, identity), (value) => {
@@ -18,14 +18,14 @@ const get = (request, response) => {
     return
   }
 
-  User.findOne({where: params}).then(user => {
-    if (isNull(user)) {
+  User.findAll({where: params, attributes: ['id']}).then(users => {
+    if (isEmpty(users)) {
       response.status(404)
       response.json({
         message: 'Not Found'
       })
     } else {
-      new Placement(user).calculate().then(placement => {
+      new Placement(users[0]).calculate().then(placement => {
         response.json({placement: placement.placement})
       }, error => {
         response.status(400)

--- a/api/controllers/recommendations.js
+++ b/api/controllers/recommendations.js
@@ -5,18 +5,19 @@ const Recommendation = require('../../models/recommendation')
 const User = require('../../models/user')
 const Placement = require('../../models/placement')
 const {Op} = require('sequelize')
-const {shuffle} = require('lodash')
+const {isEmpty, shuffle} = require('lodash')
 
 const get = async (request, response) => {
   try {
-    const [page, user] = await Promise.all([
+    const [page, users] = await Promise.all([
       Recommendation.findById(request.query['entity.id']),
-      User.findOne({where: {mcid: {[Op.contains]: [request.query['profile.mcid']]}}})
+      User.findAll({where: {mcid: {[Op.contains]: [request.query['profile.mcid']]}}, attributes: ['id']})
     ])
-    if (page === null || user === null) {
+    if (page === null || isEmpty(users)) {
       return render404(response)
     }
 
+    const user = users[0]
     const placement = await (new Placement(user).calculate())
     if (placement.placement === null) {
       return render404(response)

--- a/test/controllers/placement.test.js
+++ b/test/controllers/placement.test.js
@@ -50,7 +50,7 @@ describe('Placement controller', () => {
         expect(status).toEqual(404)
       })
 
-      jest.spyOn(User, 'findOne').mockResolvedValue(null)
+      jest.spyOn(User, 'findAll').mockResolvedValue([])
 
       controller.get({query: {mcid: '1234'}}, response)
     })
@@ -70,7 +70,7 @@ describe('Placement controller', () => {
         expect(status).toEqual(400)
       })
 
-      jest.spyOn(User, 'findOne').mockRejectedValue(new Error('error message'))
+      jest.spyOn(User, 'findAll').mockRejectedValue(new Error('error message'))
 
       controller.get({query: {mcid: '1234'}}, response)
     })
@@ -86,7 +86,7 @@ describe('Placement controller', () => {
         done()
       })
 
-      jest.spyOn(User, 'findOne').mockResolvedValue({id: 2345})
+      jest.spyOn(User, 'findAll').mockResolvedValue([{id: 2345}])
 
       Placement.mockImplementation(() => {
         return {
@@ -112,7 +112,7 @@ describe('Placement controller', () => {
         expect(status).toEqual(400)
       })
 
-      jest.spyOn(User, 'findOne').mockResolvedValue({id: 2345})
+      jest.spyOn(User, 'findAll').mockResolvedValue([{id: 2345}])
 
       Placement.mockImplementation(() => {
         return {
@@ -134,7 +134,7 @@ describe('Placement controller', () => {
         done()
       })
 
-      jest.spyOn(User, 'findOne').mockResolvedValue({id: 2345})
+      jest.spyOn(User, 'findAll').mockResolvedValue([{id: 2345}])
 
       Placement.mockImplementation(() => {
         return {

--- a/test/controllers/recommendations.test.js
+++ b/test/controllers/recommendations.test.js
@@ -44,7 +44,7 @@ describe('Recommendations controller', () => {
   describe('user has no placement', () => {
     it('should return 404 Not Found', async () => {
       jest.spyOn(Recommendation, 'findById').mockResolvedValue(new Recommendation({id: 'abc123'}))
-      jest.spyOn(User, 'findAll').mockResolvedValue([new User({id: 123456, mcid: ['809xyz']})])
+      jest.spyOn(User, 'findAll').mockResolvedValue([new User({id: 123456})])
       Placement.mockImplementation(() => {
         return {
           calculate: jest.fn().mockResolvedValue({placement: null})
@@ -61,7 +61,7 @@ describe('Recommendations controller', () => {
     it('should return 404 Not Found', async () => {
       const recommendedSpy = jest.fn()
       jest.spyOn(Recommendation, 'findById').mockResolvedValue({findRecommended: recommendedSpy})
-      jest.spyOn(User, 'findAll').mockResolvedValue([new User({id: 123456, mcid: ['809xyz']})])
+      jest.spyOn(User, 'findAll').mockResolvedValue([new User({id: 123456})])
       Placement.mockImplementation(() => {
         return {
           calculate: jest.fn().mockResolvedValue({placement: 6})
@@ -82,7 +82,7 @@ describe('Recommendations controller', () => {
       recommendedSpy = jest.fn()
       page = {findRecommended: recommendedSpy, category: 'A Category'}
       jest.spyOn(Recommendation, 'findById').mockResolvedValue(page)
-      jest.spyOn(User, 'findAll').mockResolvedValue([new User({id: 123456, mcid: ['809xyz']})])
+      jest.spyOn(User, 'findAll').mockResolvedValue([new User({id: 123456})])
       Placement.mockImplementation(() => {
         return {
           calculate: jest.fn().mockResolvedValue({placement: 6})

--- a/test/controllers/recommendations.test.js
+++ b/test/controllers/recommendations.test.js
@@ -44,7 +44,7 @@ describe('Recommendations controller', () => {
   describe('user has no placement', () => {
     it('should return 404 Not Found', async () => {
       jest.spyOn(Recommendation, 'findById').mockResolvedValue(new Recommendation({id: 'abc123'}))
-      jest.spyOn(User, 'findOne').mockResolvedValue(new User({id: 123456, mcid: ['809xyz']}))
+      jest.spyOn(User, 'findAll').mockResolvedValue([new User({id: 123456, mcid: ['809xyz']})])
       Placement.mockImplementation(() => {
         return {
           calculate: jest.fn().mockResolvedValue({placement: null})
@@ -61,7 +61,7 @@ describe('Recommendations controller', () => {
     it('should return 404 Not Found', async () => {
       const recommendedSpy = jest.fn()
       jest.spyOn(Recommendation, 'findById').mockResolvedValue({findRecommended: recommendedSpy})
-      jest.spyOn(User, 'findOne').mockResolvedValue(new User({id: 123456, mcid: ['809xyz']}))
+      jest.spyOn(User, 'findAll').mockResolvedValue([new User({id: 123456, mcid: ['809xyz']})])
       Placement.mockImplementation(() => {
         return {
           calculate: jest.fn().mockResolvedValue({placement: 6})
@@ -82,7 +82,7 @@ describe('Recommendations controller', () => {
       recommendedSpy = jest.fn()
       page = {findRecommended: recommendedSpy, category: 'A Category'}
       jest.spyOn(Recommendation, 'findById').mockResolvedValue(page)
-      jest.spyOn(User, 'findOne').mockResolvedValue(new User({id: 123456, mcid: ['809xyz']}))
+      jest.spyOn(User, 'findAll').mockResolvedValue([new User({id: 123456, mcid: ['809xyz']})])
       Placement.mockImplementation(() => {
         return {
           calculate: jest.fn().mockResolvedValue({placement: 6})


### PR DESCRIPTION
Testing says this should fix the majority of https://rollbar.com/Cru/scale-of-belief-lambda/items/35/

At least once per day, for a few hours, the postgres query planner is deciding it's going to be quicker to do a table scan than using the indexes. This is causing the timeouts. Removing the LIMIT 1 causes the query planner to always use the indexes. Rarely will we get more than 1 user, and when we do, just take the first (It's what LIMIT 1 would of done anyway).

This also limits the columns selected to just `id`, which is the only column used.