### PR TITLE
Ensure stacktraces are recorded by rollbar

### DIFF
--- a/scheduled/redshift.js
+++ b/scheduled/redshift.js
@@ -187,7 +187,7 @@ module.exports.handler = rollbar.lambdaHandler((lambdaEvent, lambdaContext, lamb
     lambdaCallback(null, 'Redshift deltas successful.')
   }, err => {
     redisClient.quit()
-    rollbar.error('Redshift: ' + err)
+    rollbar.error('Redshift: ' + err, err)
     lambdaCallback(err)
   })
 })

--- a/scheduled/refresh-materialized.js
+++ b/scheduled/refresh-materialized.js
@@ -12,7 +12,7 @@ module.exports.handler = async (lambdaEvent) => {
     await sequelize().query('REFRESH MATERIALIZED VIEW unscored')
     return await RecentlyScored.destroy({truncate: true})
   } catch (error) {
-    rollbar.error('Error refreshing the materialized view: unscored: ' + error)
+    rollbar.error('Error refreshing the materialized view: unscored: ' + error, error)
     throw error
   }
 }

--- a/sns/campaign.js
+++ b/sns/campaign.js
@@ -78,7 +78,7 @@ module.exports = {
     asyncHandler(JSON.parse(snsMessage)).then((message) => {
       lambdaCallback(null, message)
     }).catch((error) => {
-      rollbar.error('Something went wrong while sending the placement to Campaign: ' + error)
+      rollbar.error('Something went wrong while sending the placement to Campaign: ' + error, error)
       lambdaCallback('Failed to send placement to Campaign: ' + error)
     })
   }),

--- a/sns/global-registry.js
+++ b/sns/global-registry.js
@@ -11,7 +11,7 @@ module.exports.handler = async (lambdaEvent) => {
     // Update Global Registry
     await GlobalRegistry.updatePlacement(message.grMasterPersonIds, message.placement)
   } catch (err) {
-    rollbar.error('Global Registry update error: ' + err)
+    rollbar.error('Global Registry update error: ' + err, err)
     throw err
   }
 }

--- a/sns/sync-score.js
+++ b/sns/sync-score.js
@@ -13,7 +13,7 @@ module.exports.handler = async (lambdaEvent) => {
     // Update score in AEM
     await AemClient.updateScore(url.parse(message.uri), message.score)
   } catch (err) {
-    rollbar.error('Error syncing score update to AEM: ' + err)
+    rollbar.error('Error syncing score update to AEM: ' + err, err)
     throw err
   }
 }


### PR DESCRIPTION
Some rollbar.error() calls sent an Error argument, but many did not,
which results in rollbar.js missing a stack trace in its report.
This adds the Error as a second argument in these cases.