### PR TITLE
User and stitcher update

### DIFF
--- a/models/identity-stitcher.js
+++ b/models/identity-stitcher.js
@@ -23,13 +23,15 @@ const {
 } = require('lodash')
 const TestUserGuids = [
   '49e1f2f9-55cc-6c10-58ff-b9b46ca79579', // test@test.com
-  'fd8c0e67-d19e-49c5-94c2-ff737302d2bc' // bill.test@tester.com
+  'fd8c0e67-d19e-49c5-94c2-ff737302d2bc', // bill.test@tester.com
+  'f51870d2-23d4-4574-94e1-dd12127a7680' // ert.test@cru.org
 ]
 const TestUserGRIds = [
   '6017a717-251c-434f-aa2f-e4279328fa59', // test@test.com
   'f19c4ec2-057d-4b7b-958b-e88452881a28',
   '2c4b60d4-7b21-43f7-836f-4f255330ecd2',
-  '8a9f5933-b4e1-4ec2-a072-f5ff34e349e6' // bill.test@tester.com
+  '8a9f5933-b4e1-4ec2-a072-f5ff34e349e6', // bill.test@tester.com
+  'd067ce6b-4f44-4edd-8a0d-8959ee18cc2b' // ert.test@cru.org
 ]
 
 /**

--- a/models/identity-stitcher.js
+++ b/models/identity-stitcher.js
@@ -235,10 +235,10 @@ const isSameSame = (user, other) => {
   // If sso_guid exists on both, and is different, it's not the same
   if (user.has_sso_guid && other.has_sso_guid && matches['sso_guid'].length === 0) return false
 
-  // If device_idfa match, then it's the same user
-  if (matches['device_idfa'].length > 0) return true
+  // If device_idfa or mcid match, then it's the same user
+  if (matches['device_idfa'].length > 0 || matches['mcid'].length > 0) return true
 
-  // If device_idfa exists on both and is different, t's not the same
+  // If device_idfa exists on both and is different, it's not the same
   if (user.has_device_idfa && other.has_device_idfa && matches['device_idfa'].length === 0) return false
 
   // If at least 2 fields match, it's the same user

--- a/models/identity-stitcher.test.js
+++ b/models/identity-stitcher.test.js
@@ -116,7 +116,8 @@ describe('IdentityStitcher', () => {
           others[1].gr_master_person_id, others[2].gr_master_person_id))
         expect(identity).toBeInstanceOf(User)
         expect(identity.id).toEqual(others[0].id)
-        expect(auditSpy).toHaveBeenCalledWith([{id: identity.id, old_id: others[2].id}], expect.anything())
+        expect(auditSpy).toHaveBeenCalledWith([{id: identity.id, old_id: others[2].id},
+          {id: identity.id, old_id: others[1].id}], expect.anything())
         expect(event.user_id).toEqual(identity.id)
         expect(sortBy(identity.mcid)).toEqual(sortBy(mcids))
         expect(identity.gr_master_person_id).toEqual(expect.arrayContaining(grids))

--- a/models/user.js
+++ b/models/user.js
@@ -79,8 +79,8 @@ User.fromEvent = (event) => {
   if (context instanceof Context) {
     if (context.hasSchema(Context.SCHEMA_MOBILE)) {
       const data = context.dataFor(Context.SCHEMA_MOBILE)
-      // Todo: iOS not sending events yet, this is a guess at the property name
-      user.device_idfa = compact(map(['androidIdfa', 'appleIdfa'], field => {
+      // https://github.com/snowplow/iglu-central/blob/master/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
+      user.device_idfa = compact(map(['androidIdfa', 'appleIdfa', 'appleIdfv', 'openIdfa'], field => {
         return data[field]
       }))
     }


### PR DESCRIPTION
Updates stitcher logic to match on `mcid`
Include `appleIdfv` and `openIdfa` in `device_idfa` values.
Ignore events from `ert.test@cru.org`