### PR TITLE
Fix invalid s3 arn.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -48,8 +48,8 @@ provider:
       Action:
         - s3:PutObject
       Resource:
-        - arn:aws:s3::056154071827:uri-scoring
-        - arn:aws:s3::056154071827:uri-scoring/*
+        - arn:aws:s3:::uri-scoring
+        - arn:aws:s3:::uri-scoring/*
   environment: ${file(serverless/environment.js)}
 
 functions:


### PR DESCRIPTION
Resource arn:aws:s3::056154071827:uri-scoring cannot contain an account id.