### PR TITLE
Use deploy role to invoke migrations

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -4,7 +4,7 @@ custom:
   scripts:
     hooks:
       # Run database migrations
-      'aws:deploy:finalize:cleanup': './node_modules/.bin/serverless --stage $ENVIRONMENT invoke --function migrate'
+      'aws:deploy:finalize:cleanup': 'npx serverless --stage $ENVIRONMENT invoke --function migrate --aws-profile serverless'
   environmentMap:
     production: prod
     staging: stage


### PR DESCRIPTION
Use the new terraform managed role to invoke the migrations. Jenkins instance role (used by default) doesn't have permissions anymore.